### PR TITLE
Deleting code duplication

### DIFF
--- a/Unwrap/Swift42.swift
+++ b/Unwrap/Swift42.swift
@@ -53,13 +53,12 @@ extension Array {
         return self[randomIndex]
     }
 
-    // Shuffles an array in place.
+    /// Shuffles an array in place.
     mutating func shuffle() {
-        // swiftlint:disable:next force_cast
-        self = (self as NSArray).shuffled() as! [Element]
+        self = self.shuffled()
     }
 
-    // Shuffles an array and returns the shuffled result.
+    /// Shuffles an array and returns the shuffled result.
     func shuffled() -> [Element] {
         // swiftlint:disable:next force_cast
         return (self as NSArray).shuffled() as! [Element]


### PR DESCRIPTION
This PR removes code duplication (since Array.shuffled() is already implemented in the extension) and fixes comments above function's names so they will act as descriptions.