### PR TITLE
Mention to open workspace file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ At some point hopefully soon Unwrap will be available to download for free on th
 
 ## Trying it yourself
 
-Unwrap is written using Xcode 9.4 and Swift 4.1. All the CocoaPods are checked in to this repository, so you should be able to clone this and build it immediately.
+Unwrap is written using Xcode 9.4 and Swift 4.1. All the CocoaPods are checked in to this repository, so you should be able to clone this and build it immediately by opening `Unwrap.xcworkspace`.
 
 As far as I know the app is feature complete, but there are likely to be errors all over the place at least to begin with – if you hit problems, either building or running the app, please let me know.
 


### PR DESCRIPTION
To avoid opening the Xcode project file added a line to open workspace file. There were a couple of issues regarding that. So added an extra line in README