### PR TITLE
Fixed a bug in Credits screen.

### DIFF
--- a/Unwrap/Activities/Home/Help/Credits/CreditsViewController.swift
+++ b/Unwrap/Activities/Home/Help/Credits/CreditsViewController.swift
@@ -19,4 +19,10 @@ class CreditsViewController: UIViewController, Storyboarded {
         let contents = String(bundleName: "Credits.md")
         textView.attributedText = contents.fromSimpleMarkdown()
     }
+
+    override func viewDidLayoutSubviews() {
+        // Set content offset to zero to make sure textview start from the top
+        // when view is laid out.
+        textView.setContentOffset(CGPoint.zero, animated: false)
+    }
 }

--- a/Unwrap/Activities/Home/Help/Credits/CreditsViewController.swift
+++ b/Unwrap/Activities/Home/Help/Credits/CreditsViewController.swift
@@ -21,8 +21,8 @@ class CreditsViewController: UIViewController, Storyboarded {
     }
 
     override func viewDidLayoutSubviews() {
-        // Set content offset to zero to make sure textview start from the top
-        // when view is laid out.
-        textView.setContentOffset(CGPoint.zero, animated: false)
+        // Set content offset to zero to make sure the textview starts from the top
+        // when the view is laid out.
+        textView.setContentOffset(.zero, animated: false)
     }
 }


### PR DESCRIPTION
In credits screen content of the textview was pre-scrolled when navigated to the screen.

<img width="500" alt="screen shot 2018-08-21 at 2 17 38 pm" src="https://user-images.githubusercontent.com/9416779/44394464-b0fae700-a550-11e8-94de-01bb4fdb0118.png">

Explicitly set the content offset to zero after view is laid out to fix the issue.