### PR TITLE
Scrolls to top when tapping UITabBarItem

### DIFF
--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2B169FF7212C3E0200BCA73D /* UIScrollView-ProgrammaticScrolling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B169FF6212C3E0200BCA73D /* UIScrollView-ProgrammaticScrolling.swift */; };
 		4DF330FA7B825B71886020E9 /* Pods_UnwrapTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4DFD8A2C064B3B2E474D67A1 /* Pods_UnwrapTests.framework */; };
 		510539F8211300D400B28328 /* UIImage-Sharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510539F7211300D400B28328 /* UIImage-Sharing.swift */; };
 		510539FA211307E800B28328 /* CoordinatedNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510539F9211307E800B28328 /* CoordinatedNavigationController.swift */; };
@@ -596,6 +597,7 @@
 
 /* Begin PBXFileReference section */
 		1042D2A80E9E96DA0B7C6F35 /* Pods_Unwrap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Unwrap.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2B169FF6212C3E0200BCA73D /* UIScrollView-ProgrammaticScrolling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView-ProgrammaticScrolling.swift"; sourceTree = "<group>"; };
 		3F6890166B1F5B8EB91C8313 /* Pods-UnwrapTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnwrapTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-UnwrapTests/Pods-UnwrapTests.release.xcconfig"; sourceTree = "<group>"; };
 		4DFD8A2C064B3B2E474D67A1 /* Pods_UnwrapTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnwrapTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		510539F7211300D400B28328 /* UIImage-Sharing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage-Sharing.swift"; sourceTree = "<group>"; };
@@ -1611,6 +1613,7 @@
 				5153F49920EF8581009E829D /* UITableViewCell-Styling.swift */,
 				5153F4AD20F007EF009E829D /* UIViewController-Alerts.swift */,
 				511FD6B02105F07A0023E92C /* URL-String.swift */,
+				2B169FF6212C3E0200BCA73D /* UIScrollView-ProgrammaticScrolling.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2769,6 +2772,7 @@
 				5153F4AE20F007EF009E829D /* UIViewController-Alerts.swift in Sources */,
 				51A6D66020E68E3100FB6B46 /* String-Letters.swift in Sources */,
 				518FAE7420E3C067007F4675 /* AlertViewController.swift in Sources */,
+				2B169FF7212C3E0200BCA73D /* UIScrollView-ProgrammaticScrolling.swift in Sources */,
 				51596DEE20EE2B5B00952ADC /* TapToCodeDataSource.swift in Sources */,
 				5189D9DF20EADA3E00E6E1D3 /* UIView-EditingToolbar.swift in Sources */,
 				5153F4A820EFCD29009E829D /* Skippable.swift in Sources */,
@@ -3030,7 +3034,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = B5C26XE59E;
+				DEVELOPMENT_TEAM = 4WDGXAFZJ6;
 				INFOPLIST_FILE = Unwrap/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3049,7 +3053,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = B5C26XE59E;
+				DEVELOPMENT_TEAM = 4WDGXAFZJ6;
 				INFOPLIST_FILE = Unwrap/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2B169FF7212C3E0200BCA73D /* UIScrollView-ProgrammaticScrolling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B169FF6212C3E0200BCA73D /* UIScrollView-ProgrammaticScrolling.swift */; };
+		2B169FF9212C6BE600BCA73D /* UINavigationBar-BarSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B169FF8212C6BE600BCA73D /* UINavigationBar-BarSize.swift */; };
 		4DF330FA7B825B71886020E9 /* Pods_UnwrapTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4DFD8A2C064B3B2E474D67A1 /* Pods_UnwrapTests.framework */; };
 		510539F8211300D400B28328 /* UIImage-Sharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510539F7211300D400B28328 /* UIImage-Sharing.swift */; };
 		510539FA211307E800B28328 /* CoordinatedNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510539F9211307E800B28328 /* CoordinatedNavigationController.swift */; };
@@ -598,6 +599,7 @@
 /* Begin PBXFileReference section */
 		1042D2A80E9E96DA0B7C6F35 /* Pods_Unwrap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Unwrap.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B169FF6212C3E0200BCA73D /* UIScrollView-ProgrammaticScrolling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView-ProgrammaticScrolling.swift"; sourceTree = "<group>"; };
+		2B169FF8212C6BE600BCA73D /* UINavigationBar-BarSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationBar-BarSize.swift"; sourceTree = "<group>"; };
 		3F6890166B1F5B8EB91C8313 /* Pods-UnwrapTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnwrapTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-UnwrapTests/Pods-UnwrapTests.release.xcconfig"; sourceTree = "<group>"; };
 		4DFD8A2C064B3B2E474D67A1 /* Pods_UnwrapTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnwrapTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		510539F7211300D400B28328 /* UIImage-Sharing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage-Sharing.swift"; sourceTree = "<group>"; };
@@ -1614,6 +1616,7 @@
 				5153F4AD20F007EF009E829D /* UIViewController-Alerts.swift */,
 				511FD6B02105F07A0023E92C /* URL-String.swift */,
 				2B169FF6212C3E0200BCA73D /* UIScrollView-ProgrammaticScrolling.swift */,
+				2B169FF8212C6BE600BCA73D /* UINavigationBar-BarSize.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2759,6 +2762,7 @@
 				5153F49220EF7430009E829D /* LearnCoordinator.swift in Sources */,
 				51A4476B2108A108005D8665 /* Badge.swift in Sources */,
 				5192587120E2A46500A85704 /* Swift42.swift in Sources */,
+				2B169FF9212C6BE600BCA73D /* UINavigationBar-BarSize.swift in Sources */,
 				51C5642920CCC2520093030C /* LearnDataSource.swift in Sources */,
 				511FD6C62107CE9C0023E92C /* AlertHandling.swift in Sources */,
 				510539F8211300D400B28328 /* UIImage-Sharing.swift in Sources */,

--- a/Unwrap/Extensions/UINavigationBar-BarSize.swift
+++ b/Unwrap/Extensions/UINavigationBar-BarSize.swift
@@ -1,0 +1,17 @@
+//
+//  UINavigationBar-BarSize.swift
+//  Unwrap
+//
+//  Created by Ian Manor on 21/08/18.
+//  Copyright © 2018 Hacking with Swift. All rights reserved.
+//
+
+import UIKit
+
+extension UINavigationBar
+{
+    var largeTitleHeight: CGFloat {
+        //TODO: Return navigation bar height difference dynamically
+        return 52
+    }
+}

--- a/Unwrap/Extensions/UIScrollView-ProgrammaticScrolling.swift
+++ b/Unwrap/Extensions/UIScrollView-ProgrammaticScrolling.swift
@@ -1,0 +1,22 @@
+//
+//  UIScrollView-ProgrammaticScrolling.swift
+//  Unwrap
+//
+//  Created by Ian Manor on 21/08/18.
+//  Copyright © 2018 Hacking with Swift. All rights reserved.
+//
+
+import UIKit
+
+extension UIScrollView {
+    
+    var scrolledToTop: Bool {
+        let topEdge = 0 - contentInset.top
+        return contentOffset.y <= topEdge
+    }
+    
+    //animates scrolling to top of scrollview
+    func scrollToTop() {
+        self.setContentOffset(CGPoint(x: 0.0, y: -self.adjustedContentInset.top - 52), animated: true)
+    }
+}

--- a/Unwrap/Extensions/UIScrollView-ProgrammaticScrolling.swift
+++ b/Unwrap/Extensions/UIScrollView-ProgrammaticScrolling.swift
@@ -15,8 +15,8 @@ extension UIScrollView {
         return contentOffset.y <= topEdge
     }
     
-    //animates scrolling to top of scrollview
-    func scrollToTop() {
-        self.setContentOffset(CGPoint(x: 0.0, y: -self.adjustedContentInset.top - 52), animated: true)
+    /// Animates scrolling to top of scrollview
+    func scrollToTop(maxNavBarHeight: CGFloat) {
+        self.setContentOffset(CGPoint(x: 0.0, y: -self.adjustedContentInset.top - maxNavBarHeight), animated: true)
     }
 }

--- a/Unwrap/MainTabBarController.swift
+++ b/Unwrap/MainTabBarController.swift
@@ -41,16 +41,22 @@ class MainTabBarController: UITabBarController, UITabBarControllerDelegate, Stor
         }
     }
     
+    /// Scrolls to top of view when user taps on the current view controller's icon
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
-        if viewController == previousViewController {
-            if let scrollView = (viewController as? UINavigationController)?.viewControllers.first?.view as? UIScrollView {
-                if !scrollView.scrolledToTop {
-                    scrollView.scrollToTop()
-                }
-            }
+        defer {
+            previousViewController = viewController
         }
         
-        previousViewController = viewController
+        guard viewController == previousViewController else { return }
+        
+        guard let navigationController = viewController as? UINavigationController else { return }
+        
+        guard let scrollView = navigationController.viewControllers.first?.view as? UIScrollView else { return }
+        
+        if !scrollView.scrolledToTop {
+            let navigationBarMaxHeight = navigationController.navigationBar.largeTitleHeight
+            scrollView.scrollToTop(maxNavBarHeight: navigationBarMaxHeight)
+        }
         
     }
 }

--- a/Unwrap/MainTabBarController.swift
+++ b/Unwrap/MainTabBarController.swift
@@ -9,17 +9,23 @@
 import UIKit
 
 /// A UITabBarController subclass that sets up our main coordinators as each of the five app tabs.
-class MainTabBarController: UITabBarController, Storyboarded {
+class MainTabBarController: UITabBarController, UITabBarControllerDelegate, Storyboarded {
     let home = HomeCoordinator()
     let learn = LearnCoordinator()
     let practice = PracticeCoordinator()
     let challenges = ChallengesCoordinator()
     let news = NewsCoordinator()
+    
+    var previousViewController: UIViewController?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        self.delegate = self
 
         viewControllers = [home.navigationController, learn.navigationController, practice.navigationController, challenges.navigationController, news.navigationController]
+        
+        previousViewController = viewControllers?.first
     }
 
     /// If we get some launch options, figure out which one was requested and jump right to the correct tab.
@@ -33,5 +39,18 @@ class MainTabBarController: UITabBarController, Storyboarded {
                 fatalError("Unknown shortcut item type: \(shortcutItem.type).")
             }
         }
+    }
+    
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        if viewController == previousViewController {
+            if let scrollView = (viewController as? UINavigationController)?.viewControllers.first?.view as? UIScrollView {
+                if !scrollView.scrolledToTop {
+                    scrollView.scrollToTop()
+                }
+            }
+        }
+        
+        previousViewController = viewController
+        
     }
 }


### PR DESCRIPTION
Resolution for issue #16. Scrolling to top requires knowledge of navigation bar size with the iOS 11 large title, which is hardcoded. Would be nice if someone found a way to add that dynamically.