### PR TITLE
The word summary was missing from the title

### DIFF
--- a/Unwrap/Content/SixtySeconds/protocols-and-extensions-summary.json
+++ b/Unwrap/Content/SixtySeconds/protocols-and-extensions-summary.json
@@ -1,5 +1,5 @@
 {
-    "title": "Protocols and extensions",
+    "title": "Protocols and extensions: Summary",
     "postscript": "",
     "reviewType": "singleSelection",
     "question": "Which of these are valid in Swift?",


### PR DESCRIPTION
This is resolution for issue #39

The image shows the problem that the learnedSections did not have the word "-summary"
<img width="372" alt="screen shot 2018-10-23 at 5 11 18 am" src="https://user-images.githubusercontent.com/705433/47351752-ac54cb00-d686-11e8-91c8-084a4696a60f.png">

Fix ended up being super simple. The name of the section from the Chapters.json did not match the name in the protocols-and-extension-summary.json. The name in the protocols-and-extension-summary.json was missing ": Summary". After I added that in then deleted and reinstalled the app I am now able to finish the section.
