### PR TITLE
Update Chapters.json

### DIFF
--- a/Unwrap/Content/SixtySeconds/Chapters.json
+++ b/Unwrap/Content/SixtySeconds/Chapters.json
@@ -31,7 +31,7 @@
 	{
 		"name": "Operators and conditions",
 		"sections": [
-			"Arithmetic Operators",
+			"Arithmetic operators",
 			"Operator overloading",
 			"Compound assignment operators",
 			"Comparison operators",


### PR DESCRIPTION
"Arithmetic Operators" should be "Arithmetic operators" for capitalization consistency in the chapter names.