### PR TITLE
Change an "a" to "at"

### DIFF
--- a/Unwrap/Content/SixtySeconds/returning-closures-from-functions.html
+++ b/Unwrap/Content/SixtySeconds/returning-closures-from-functions.html
@@ -1,5 +1,5 @@
 <p>In the same way that you can pass a closure <em>to</em> a function, you can get closures returned <em>from</em> a function too.</p>
-<p>The syntax for this is a bit confusing a first, because it uses <code>-&gt;</code> twice: once to specify your function’s return value, and a second time to specify your closure’s return value.</p>
+<p>The syntax for this is a bit confusing at first, because it uses <code>-&gt;</code> twice: once to specify your function’s return value, and a second time to specify your closure’s return value.</p>
 <p>To try this out, we’re going to write a <code>travel()</code> function that accepts no parameters, but returns a closure. The closure that gets returned must be called with a string, and will return nothing.</p>
 <p>Here’s how that looks in Swift:</p>
 <pre class="code">


### PR DESCRIPTION
In the second line, I changed an "a" to "at" in ". . . is a bit confusing a first," so it reads "... is a bit confusing at first,"