### PR TITLE
Update static-properties-and-methods.json

### DIFF
--- a/Unwrap/Content/SixtySeconds/static-properties-and-methods.json
+++ b/Unwrap/Content/SixtySeconds/static-properties-and-methods.json
@@ -1,6 +1,6 @@
 {
     "title": "Static properties and methods",
-    "postscript": "Static methods work the same way as static methods – just write <code>static func yourMethod()</code> rather than <code>func yourMethod()</code>.",
+    "postscript": "Static methods work the same way as static properties – just write <code>static func yourMethod()</code> rather than <code>func yourMethod()</code>.",
     "reviewType": "singleSelection",
     "question": "This code is valid Swift – true or false?",
     "hint": "Static properties and methods must be called on the struct that owns them, rather than on instances of that struct.",


### PR DESCRIPTION
Used to say " Static methods work the same way as static methods -" It seems like it should say "Static methods work the same way as static properties -"