### PR TITLE
Update the streak when the day changes

### DIFF
--- a/Unwrap/User/User.swift
+++ b/Unwrap/User/User.swift
@@ -144,6 +144,7 @@ final class User: Codable {
 
     // MARK: Methods
     init() {
+        NotificationCenter.default.addObserver(self, selector: #selector(updateStreak), name: .NSCalendarDayChanged, object: nil)
         updateStreak()
     }
 
@@ -168,6 +169,8 @@ final class User: Codable {
         readNewsCount = try container.decode(Int.self, forKey: .readNewsCount)
 
         theme = try container.decode(String.self, forKey: .theme)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(updateStreak), name: .NSCalendarDayChanged, object: nil)
 
         updateStreak()
     }
@@ -304,7 +307,7 @@ final class User: Codable {
     }
 
     /// Called whenever we need to update our streak. This checks whether the streak should be updated, then either carries it out or resets the streak if more than 1 day has passed.
-    func updateStreak() {
+    @objc func updateStreak() {
         let today = Date()
         guard lastStreakEntry.isSameDay(as: today) == false else { return }
 

--- a/UnwrapTests/UserTests.swift
+++ b/UnwrapTests/UserTests.swift
@@ -123,9 +123,33 @@ class UserTests: XCTestCase {
     /// Tests that streaks work correctly.
     func testStreakCounting() {
         let user = User()
-        XCTAssert(user.streakDays == 1, "New users should start with a streak count of 1.")
+        XCTAssertEqual(user.streakDays, 1, "New users should start with a streak count of 1.")
 
         user.updateStreak()
-        XCTAssert(user.streakDays == 1, "Streak count should not change in the same day.")
+        XCTAssertEqual(user.streakDays, 1, "Streak count should not change in the same day.")
+
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        user.lastStreakEntry = yesterday
+        user.updateStreak()
+        XCTAssertEqual(user.streakDays, 2, "Streak count should change for next day.")
+        XCTAssertEqual(user.bestStreak, 2, "Best streak should be updated")
+    }
+
+    /// Testing best streak
+    func testBestStreakCounting() {
+        let user = User()
+
+        user.updateStreak()
+        XCTAssertEqual(user.bestStreak, 1, "Best streak should be updated")
+
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        user.lastStreakEntry = yesterday
+        user.updateStreak()
+        XCTAssertEqual(user.bestStreak, 2, "Best streak should be updated")
+
+        user.bestStreak = 25
+        user.lastStreakEntry = yesterday
+        user.updateStreak()
+        XCTAssertEqual(user.bestStreak, 25, "Best streak should not be updated")
     }
 }


### PR DESCRIPTION
Testing
1. Using the simulator open the App and get some points
2. Minimize the App
3. Change the date or what till tomorrow.
4. Open the App.

The streak is updated.

This address https://github.com/twostraws/Unwrap/issues/82