### PR TITLE
Make it a universal app

### DIFF
--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -3130,7 +3130,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.unwrapswift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -3148,7 +3148,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.unwrapswift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
It feels so much better when you can use an iPhone app on an iPad as well. If there are no bigger concerns why this app shouldn't allow universal builds then I like the user to decide which device fits best to use the app.

#29 