### PR TITLE
Make all cells on the stats section of the home view controller have …

### DIFF
--- a/Unwrap/Activities/Home/HomeDataSource.swift
+++ b/Unwrap/Activities/Home/HomeDataSource.swift
@@ -156,6 +156,7 @@ class HomeDataSource: NSObject, UITableViewDataSource {
     /// Shows how the user is progressing through levels.
     func makeStatistic(in tableView: UITableView, indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "Stat", for: indexPath)
+        cell.textLabel?.textColor = nil
 
         switch indexPath.row {
         case 0:


### PR DESCRIPTION
…the default text color

"Points Until Next Level" was showing up Blue for me. It must be reusing the same cell as the "Share Score" so I'm just forcing the nil textColor like you are doing on other cells in that same class. 