### PR TITLE
Unread notifications for news articles

### DIFF
--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		4C41E3132207C678009D580E /* ReviewPractice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C41E3122207C678009D580E /* ReviewPractice.swift */; };
 		4C7232A0221C186400D169E9 /* ReviewMultipleSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C72329F221C186400D169E9 /* ReviewMultipleSelectViewController.swift */; };
 		4C7232A2221C223600D169E9 /* ReviewSingleSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7232A1221C223600D169E9 /* ReviewSingleSelectViewController.swift */; };
+		4C8950C42253633F002F9FA6 /* NewsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8950C32253633F002F9FA6 /* NewsTableViewCell.swift */; };
 		4DF330FA7B825B71886020E9 /* Pods_UnwrapTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4DFD8A2C064B3B2E474D67A1 /* Pods_UnwrapTests.framework */; };
 		510539F8211300D400B28328 /* UIImage-Sharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510539F7211300D400B28328 /* UIImage-Sharing.swift */; };
 		510539FA211307E800B28328 /* CoordinatedNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510539F9211307E800B28328 /* CoordinatedNavigationController.swift */; };
@@ -613,6 +614,7 @@
 		4C41E3122207C678009D580E /* ReviewPractice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPractice.swift; sourceTree = "<group>"; };
 		4C72329F221C186400D169E9 /* ReviewMultipleSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewMultipleSelectViewController.swift; sourceTree = "<group>"; };
 		4C7232A1221C223600D169E9 /* ReviewSingleSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSingleSelectViewController.swift; sourceTree = "<group>"; };
+		4C8950C32253633F002F9FA6 /* NewsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsTableViewCell.swift; sourceTree = "<group>"; };
 		4DFD8A2C064B3B2E474D67A1 /* Pods_UnwrapTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnwrapTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		510539F7211300D400B28328 /* UIImage-Sharing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage-Sharing.swift"; sourceTree = "<group>"; };
 		510539F9211307E800B28328 /* CoordinatedNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatedNavigationController.swift; sourceTree = "<group>"; };
@@ -1264,11 +1266,12 @@
 		511FD6A72105CDA20023E92C /* News */ = {
 			isa = PBXGroup;
 			children = (
+				511FD6AE2105EF220023E92C /* NewsArticle.swift */,
 				511FD6AC2105E72C0023E92C /* NewsCoordinator.swift */,
 				511FD6A82105E6B00023E92C /* NewsViewController.swift */,
 				511FD6AA2105E6EB0023E92C /* NewsDataSource.swift */,
 				51FA55D8211B55DE00C38188 /* NewsEmptyDataSource.swift */,
-				511FD6AE2105EF220023E92C /* NewsArticle.swift */,
+				4C8950C32253633F002F9FA6 /* NewsTableViewCell.swift */,
 			);
 			path = News;
 			sourceTree = "<group>";
@@ -2909,6 +2912,7 @@
 				51DB1D79222D9648005CB620 /* WrongAnswer.swift in Sources */,
 				51A6D62720E651DA00FB6B46 /* FloatNames.swift in Sources */,
 				51A6D66820E6953100FB6B46 /* CodeErrorType.swift in Sources */,
+				4C8950C42253633F002F9FA6 /* NewsTableViewCell.swift in Sources */,
 				51B87CDE210B35C600FE773A /* User-StaticProperties.swift in Sources */,
 				511FD6B12105F07A0023E92C /* URL-String.swift in Sources */,
 				511FD6B821065D690023E92C /* HelpDataSource.swift in Sources */,
@@ -3126,7 +3130,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = B5C26XE59E;
+				DEVELOPMENT_TEAM = CY96495443;
 				INFOPLIST_FILE = Unwrap/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3145,7 +3149,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = B5C26XE59E;
+				DEVELOPMENT_TEAM = CY96495443;
 				INFOPLIST_FILE = Unwrap/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Unwrap/Activities/News/NewsCoordinator.swift
+++ b/Unwrap/Activities/News/NewsCoordinator.swift
@@ -35,15 +35,15 @@ class NewsCoordinator: Coordinator {
     }
 
     /// Triggered when we already have a Safari view controller configured and ready to go, so we just show it.
-    func startReading(using viewController: UIViewController) {
+    func startReading(using viewController: UIViewController, withURL url: URL) {
         navigationController.present(viewController, animated: true)
-        User.current.readNewsStory()
+        User.current.readNewsStory(forURL: url)
     }
 
     /// Creates, configures, and presents a Safari view controller for a specific article.
     func read(_ article: NewsArticle) {
         let viewController = readViewController(for: article)
-        startReading(using: viewController)
+        startReading(using: viewController, withURL: article.url)
     }
 
     /// Loads the Hacking with Swift store.

--- a/Unwrap/Activities/News/NewsDataSource.swift
+++ b/Unwrap/Activities/News/NewsDataSource.swift
@@ -76,18 +76,27 @@ class NewsDataSource: NSObject, UITableViewDataSource {
             fatalError("Unable to dequeue cell.")
         }
 
-        let article = articles[indexPath.row]
-        cell.textLabel?.text = article.title
-        cell.detailTextLabel?.text = article.strap
+        guard let newsCell = cell as? NewsTableViewCell else {
+            fatalError("Unable to create cell as a NewsTableViewCell.")
+        }
 
-        cell.imageView?.sd_cancelCurrentImageLoad()
-        cell.imageView?.sd_setImage(with: article.mainImage, placeholderImage: UIImage(bundleName: "News-Placeholder"))
+        let article = articles[indexPath.row]
+
+        if User.current.hasReadNewsStory(forURL: article.url) {
+            newsCell.readNotification.alpha = 0
+        }
+
+        newsCell.textLabel?.text = article.title
+        newsCell.detailTextLabel?.text = article.strap
+
+        newsCell.imageView?.sd_cancelCurrentImageLoad()
+        newsCell.imageView?.sd_setImage(with: article.mainImage, placeholderImage: UIImage(bundleName: "News-Placeholder"))
 
         // draw a micro-width border around images so that white images don't just spill over to the rest of the cell
-        cell.imageView?.layer.borderWidth = 1 / UIScreen.main.scale
-        cell.imageView?.layer.borderColor = UIColor.lightGray.cgColor
+        newsCell.imageView?.layer.borderWidth = 1 / UIScreen.main.scale
+        newsCell.imageView?.layer.borderColor = UIColor.lightGray.cgColor
 
-        return cell
+        return newsCell
     }
 
     /// Lets our own read articles without digging directly into the articles array.

--- a/Unwrap/Activities/News/NewsTableViewCell.swift
+++ b/Unwrap/Activities/News/NewsTableViewCell.swift
@@ -1,0 +1,16 @@
+//
+//  NewsTableViewCell.swift
+//  Unwrap
+//
+//  Created by Michael Charland on 2019-04-02.
+//  Copyright © 2019 Hacking with Swift. All rights reserved.
+//
+
+import UIKit
+
+/// Represents a row in the News table view that contains an article to read.
+class NewsTableViewCell: UITableViewCell {
+
+    /// The little splat beside the image indicating if the article has been read or not.
+    @IBOutlet weak var readNotification: UILabel!
+}

--- a/Unwrap/Activities/News/NewsViewController.swift
+++ b/Unwrap/Activities/News/NewsViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-/// The main view controller you see in  the Challenges tab in the app.
+/// The view controller you see in the News tab in the app.
 class NewsViewController: UITableViewController, Storyboarded, UIViewControllerPreviewingDelegate {
     var coordinator: NewsCoordinator?
 
@@ -17,6 +17,9 @@ class NewsViewController: UITableViewController, Storyboarded, UIViewControllerP
 
     /// This handles showing something meaningful if news download failed.
     var emptyDataSource = NewsEmptyDataSource()
+
+    /// The article that has selected by a 3D touch.
+    var currentSelectedArticle: NewsArticle!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -74,14 +77,15 @@ class NewsViewController: UITableViewController, Storyboarded, UIViewControllerP
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let article = dataSource.article(at: indexPath.row)
         coordinator?.read(article)
+        tableView.reloadData()
     }
 
     /// Called when the user 3D touches on a news story.
     func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
         if let indexPath = tableView.indexPathForRow(at: location) {
             previewingContext.sourceRect = tableView.rectForRow(at: indexPath)
-            let article = dataSource.article(at: indexPath.row)
-            return coordinator?.readViewController(for: article)
+            currentSelectedArticle = dataSource.article(at: indexPath.row)
+            return coordinator?.readViewController(for: currentSelectedArticle)
         }
 
         return nil
@@ -89,6 +93,7 @@ class NewsViewController: UITableViewController, Storyboarded, UIViewControllerP
 
     /// Called when the user 3D touches harder on a news story.
     func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        coordinator?.startReading(using: viewControllerToCommit)
+        coordinator?.startReading(using: viewControllerToCommit, withURL: currentSelectedArticle.url)
+        tableView.reloadData()
     }
 }

--- a/Unwrap/Base.lproj/Main.storyboard
+++ b/Unwrap/Base.lproj/Main.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -1381,13 +1381,20 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="Cell" textLabel="KQY-n6-S7K" detailTextLabel="Etp-Ld-k9u" style="IBUITableViewCellStyleSubtitle" id="1NR-OF-zX6">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="Cell" textLabel="KQY-n6-S7K" detailTextLabel="Etp-Ld-k9u" style="IBUITableViewCellStyleSubtitle" id="1NR-OF-zX6" customClass="NewsTableViewCell" customModule="Unwrap" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1NR-OF-zX6" id="GNJ-k6-RBG">
                                     <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="★" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6EC-1U-fcV" userLabel="Read Notification">
+                                            <rect key="frame" x="0.0" y="11" width="16" height="21"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="1" green="0.050213125070000003" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="KQY-n6-S7K">
                                             <rect key="frame" x="15" y="5" width="33.5" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
@@ -1404,6 +1411,9 @@
                                         </label>
                                     </subviews>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="readNotification" destination="6EC-1U-fcV" id="VNO-5e-D07"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>
@@ -1414,7 +1424,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cRb-7L-eZk" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2325" y="1831"/>
+            <point key="canvasLocation" x="2324" y="1830.1349325337333"/>
         </scene>
         <!--Rearrange The Lines View Controller-->
         <scene sceneID="XM7-4d-Ms1">

--- a/Unwrap/User/User.swift
+++ b/Unwrap/User/User.swift
@@ -23,7 +23,7 @@ final class User: Codable {
 
         case scoreShareCount
         case latestNewsArticle
-        case readNewsCount
+        case articlesRead
 
         case theme
     }
@@ -57,10 +57,15 @@ final class User: Codable {
     var latestNewsArticle = 0
 
     /// The number of times the user has read a news article.
-    var readNewsCount = 0
+    var readNewsCount: Int {
+        return articlesRead.count
+    }
 
     /// Tracks the currently enabled theme.
     var theme = "Light"
+
+    /// Tracks which articles the user has read.
+    var articlesRead = Set<URL>()
 
     // MARK: Computed properties
 
@@ -166,7 +171,7 @@ final class User: Codable {
 
         scoreShareCount = try container.decode(Int.self, forKey: .scoreShareCount)
         latestNewsArticle = try container.decode(Int.self, forKey: .latestNewsArticle)
-        readNewsCount = try container.decode(Int.self, forKey: .readNewsCount)
+        articlesRead = try container.decode(Set<URL>.self, forKey: .articlesRead)
 
         theme = try container.decode(String.self, forKey: .theme)
 
@@ -210,10 +215,15 @@ final class User: Codable {
         statusChanged()
     }
 
-    /// Triggered when the user reads any news story
-    func readNewsStory() {
-        readNewsCount += 1
+    /// Triggered when the user reads any news story.
+    func readNewsStory(forURL url: URL) {
+        articlesRead.insert(url)
         statusChanged()
+    }
+
+    /// Triggered when checking if the user read a news story.
+    func hasReadNewsStory(forURL url: URL) -> Bool {
+        return articlesRead.contains(url)
     }
 
     /// Sends an app-wide notification that the user's data has changed somehow, so all listening objects can update.

--- a/UnwrapTests/BadgeTests.swift
+++ b/UnwrapTests/BadgeTests.swift
@@ -137,8 +137,8 @@ class BadgeTests: XCTestCase {
             throw TestErrors.badBadge
         }
 
-        for _ in 1...targetCount {
-            user.readNewsStory()
+        for a in 1...targetCount {
+            user.readNewsStory(forURL: URL(fileURLWithPath: String(a)))
         }
 
         XCTAssertTrue(user.isBadgeEarned(readerBadge), "Reading \(targetCount) news stories should unlock the badge \(readerBadge.name).")

--- a/UnwrapTests/UserTests.swift
+++ b/UnwrapTests/UserTests.swift
@@ -101,8 +101,8 @@ class UserTests: XCTestCase {
         let user = User()
         let targetCount = 3
 
-        for _ in 1...targetCount {
-            user.readNewsStory()
+        for i in 1...targetCount {
+            user.readNewsStory(forURL: URL(fileURLWithPath: String(i)))
         }
 
         XCTAssert(user.readNewsCount == targetCount, "Reading one news story should be stored correctly.")


### PR DESCRIPTION
When you are on the news tab you can now easily see on the left side via a little red splat if you have read an article or not. As you can see by the image below "What New in Swift 5.0" and "Interview: Antoine van Lee" have both been read. All the other articles have not been.

<img src="https://user-images.githubusercontent.com/705433/55621190-d39de100-576a-11e9-9039-d2ed311f88bc.png" alt="Simulator Screen Shot - iPhone Xʀ - 2019-04-05 at 06 20 38" height="420">

Updated the unit tests and made sure they passed. Nice having them their checking if the counting for the badge still works as expected.