### PR TITLE
Show unread badge on reused cells in the NewsViewController

### DIFF
--- a/Unwrap/Activities/News/NewsDataSource.swift
+++ b/Unwrap/Activities/News/NewsDataSource.swift
@@ -85,7 +85,7 @@ class NewsDataSource: NSObject, UITableViewDataSource {
         if User.current.hasReadNewsStory(forURL: article.url) {
             newsCell.readNotification.alpha = 0
         } else {
-            newsCell.readNotification.alpha = 100
+            newsCell.readNotification.alpha = 1
         }
 
         newsCell.textLabel?.text = article.title

--- a/Unwrap/Activities/News/NewsDataSource.swift
+++ b/Unwrap/Activities/News/NewsDataSource.swift
@@ -84,6 +84,8 @@ class NewsDataSource: NSObject, UITableViewDataSource {
 
         if User.current.hasReadNewsStory(forURL: article.url) {
             newsCell.readNotification.alpha = 0
+        } else {
+            newsCell.readNotification.alpha = 100
         }
 
         newsCell.textLabel?.text = article.title


### PR DESCRIPTION
This PR fixes an issue with the blue badges added in #103 whereby reused cells would sometimes show the incorrect badge state because the badge state was not reset on reused cells.