### PR TITLE
Create more screens programmatically to reduce storyboard size

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you’d like to help, here are some suggestions ordered from most easy to mos
 
 1. Although I’m pretty happy with the app’s architecture, it could always be improved – if you have suggestions, let me know!
 2. I’ve added the basics of theme support, but it’s not implemented or tested yet. This could be expanded to work everywhere, and new themes could be added.
-3. The storyboard started off small and grew far too big for its boots. This is particularly annoying because many screens are similar. To resolve this we could switch to building the UI in code, starting with a direct copy of the storyboard, then try to refactor it so that similar view controllers are created using shared code. 
+3. The storyboard started off small and grew far too big for its boots. This is particularly annoying because many screens are similar. Some of the UI is now built in code already. To resolve this we could switch to building even more UI in code, starting with a direct copy of the storyboard, then try to refactor it so that similar view controllers are created using shared code. 
 
 Again, please make sure you read the LICENSE.md and CONTRIBUTING.md files before you start just to avoid problems.
 

--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -3134,13 +3134,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Unwrap/Unwrap.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = B5C26XE59E;
+				DEVELOPMENT_TEAM = 74N8K5J2N7;
 				INFOPLIST_FILE = Unwrap/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.unwrapswift;
+				PRODUCT_BUNDLE_IDENTIFIER = com.julianschiavo.unwrapswift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3154,13 +3154,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Unwrap/Unwrap.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = B5C26XE59E;
+				DEVELOPMENT_TEAM = 74N8K5J2N7;
 				INFOPLIST_FILE = Unwrap/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.unwrapswift;
+				PRODUCT_BUNDLE_IDENTIFIER = com.julianschiavo.unwrapswift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -588,6 +588,7 @@
 		51FE151C20E25F1200F29889 /* protocol-extensions.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 51FE139520E25F1100F29889 /* protocol-extensions.mp4 */; };
 		51FE151E20E2814E00F29889 /* StudyReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FE151D20E2814E00F29889 /* StudyReview.swift */; };
 		81EB5780E28D768D1C6D9687 /* Pods_UnwrapUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD9A9FDC401B2E4E93A13259 /* Pods_UnwrapUITests.framework */; };
+		B93AEC4B2273DB68005A50DF /* PracticeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93AEC4A2273DB68005A50DF /* PracticeTableViewCell.swift */; };
 		B96D1C3F227333BE0096492B /* GlossaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D1C3E227333BE0096492B /* GlossaryTableViewCell.swift */; };
 		FBCAB466480A05C9E3D694CF /* Pods_Unwrap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1042D2A80E9E96DA0B7C6F35 /* Pods_Unwrap.framework */; };
 /* End PBXBuildFile section */
@@ -1201,6 +1202,7 @@
 		51FE151D20E2814E00F29889 /* StudyReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyReview.swift; sourceTree = "<group>"; };
 		879EE4E91437B6378BB24AE1 /* Pods-Unwrap.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unwrap.release.xcconfig"; path = "Pods/Target Support Files/Pods-Unwrap/Pods-Unwrap.release.xcconfig"; sourceTree = "<group>"; };
 		AA4718A94B659E9A42AEC33E /* Pods-UnwrapTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnwrapTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnwrapTests/Pods-UnwrapTests.debug.xcconfig"; sourceTree = "<group>"; };
+		B93AEC4A2273DB68005A50DF /* PracticeTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTableViewCell.swift; sourceTree = "<group>"; };
 		B96D1C3E227333BE0096492B /* GlossaryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlossaryTableViewCell.swift; sourceTree = "<group>"; };
 		BB24D72F99ED46CE1F202A82 /* Pods-Unwrap.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unwrap.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Unwrap/Pods-Unwrap.debug.xcconfig"; sourceTree = "<group>"; };
 		BE61552411B754C7764869FE /* Pods-UnwrapUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnwrapUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnwrapUITests/Pods-UnwrapUITests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1544,6 +1546,7 @@
 				5153F49520EF762B009E829D /* PracticeCoordinator.swift */,
 				51C5642220CCB82B0093030C /* PracticeViewController.swift */,
 				51862E6720CE7DE40086CD1B /* PracticeDataSource.swift */,
+				B93AEC4A2273DB68005A50DF /* PracticeTableViewCell.swift */,
 				51862E6920CE84FB0086CD1B /* PracticeActivity.swift */,
 				5153F49B20EF917B009E829D /* PracticingViewController.swift */,
 			);
@@ -2863,6 +2866,7 @@
 				51596DEC20EE1C9F00952ADC /* WordCollectionViewCell.swift in Sources */,
 				51A6D62320E651DA00FB6B46 /* DoubleNames.swift in Sources */,
 				5153F49620EF762B009E829D /* PracticeCoordinator.swift in Sources */,
+				B93AEC4B2273DB68005A50DF /* PracticeTableViewCell.swift in Sources */,
 				4C7232A2221C223600D169E9 /* ReviewSingleSelectViewController.swift in Sources */,
 				51A6D63620E6539200FB6B46 /* FreeCodingQuestion.swift in Sources */,
 				5153F4AE20F007EF009E829D /* UIViewController-Alerts.swift in Sources */,

--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -588,6 +588,7 @@
 		51FE151C20E25F1200F29889 /* protocol-extensions.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 51FE139520E25F1100F29889 /* protocol-extensions.mp4 */; };
 		51FE151E20E2814E00F29889 /* StudyReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FE151D20E2814E00F29889 /* StudyReview.swift */; };
 		81EB5780E28D768D1C6D9687 /* Pods_UnwrapUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD9A9FDC401B2E4E93A13259 /* Pods_UnwrapUITests.framework */; };
+		B96D1C3F227333BE0096492B /* GlossaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D1C3E227333BE0096492B /* GlossaryTableViewCell.swift */; };
 		FBCAB466480A05C9E3D694CF /* Pods_Unwrap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1042D2A80E9E96DA0B7C6F35 /* Pods_Unwrap.framework */; };
 /* End PBXBuildFile section */
 
@@ -1200,6 +1201,7 @@
 		51FE151D20E2814E00F29889 /* StudyReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyReview.swift; sourceTree = "<group>"; };
 		879EE4E91437B6378BB24AE1 /* Pods-Unwrap.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unwrap.release.xcconfig"; path = "Pods/Target Support Files/Pods-Unwrap/Pods-Unwrap.release.xcconfig"; sourceTree = "<group>"; };
 		AA4718A94B659E9A42AEC33E /* Pods-UnwrapTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnwrapTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnwrapTests/Pods-UnwrapTests.debug.xcconfig"; sourceTree = "<group>"; };
+		B96D1C3E227333BE0096492B /* GlossaryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlossaryTableViewCell.swift; sourceTree = "<group>"; };
 		BB24D72F99ED46CE1F202A82 /* Pods-Unwrap.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unwrap.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Unwrap/Pods-Unwrap.debug.xcconfig"; sourceTree = "<group>"; };
 		BE61552411B754C7764869FE /* Pods-UnwrapUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnwrapUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnwrapUITests/Pods-UnwrapUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		BE64715D944F01A45D8EE2EB /* Pods-UnwrapUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnwrapUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-UnwrapUITests/Pods-UnwrapUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1294,6 +1296,7 @@
 			children = (
 				514BF46921E6691A00DE1483 /* GlossaryViewController.swift */,
 				514BF46B21E6693100DE1483 /* GlossaryDataSource.swift */,
+				B96D1C3E227333BE0096492B /* GlossaryTableViewCell.swift */,
 				514BF46D21E6698C00DE1483 /* GlossaryEntry.swift */,
 			);
 			path = Glossary;
@@ -2856,6 +2859,7 @@
 				51A6D66C20E696A300FB6B46 /* SpotTheErrorPractice.swift in Sources */,
 				514BF46E21E6698C00DE1483 /* GlossaryEntry.swift in Sources */,
 				51C5642520CCB8350093030C /* ChallengesViewController.swift in Sources */,
+				B96D1C3F227333BE0096492B /* GlossaryTableViewCell.swift in Sources */,
 				51596DEC20EE1C9F00952ADC /* WordCollectionViewCell.swift in Sources */,
 				51A6D62320E651DA00FB6B46 /* DoubleNames.swift in Sources */,
 				5153F49620EF762B009E829D /* PracticeCoordinator.swift in Sources */,

--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -589,6 +589,8 @@
 		51FE151E20E2814E00F29889 /* StudyReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FE151D20E2814E00F29889 /* StudyReview.swift */; };
 		81EB5780E28D768D1C6D9687 /* Pods_UnwrapUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD9A9FDC401B2E4E93A13259 /* Pods_UnwrapUITests.framework */; };
 		B93AEC4B2273DB68005A50DF /* PracticeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93AEC4A2273DB68005A50DF /* PracticeTableViewCell.swift */; };
+		B93AEC4D2273DE70005A50DF /* ChallengeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93AEC4C2273DE70005A50DF /* ChallengeTableViewCell.swift */; };
+		B93AEC4F2273DF03005A50DF /* PreviousChallengeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93AEC4E2273DF03005A50DF /* PreviousChallengeTableViewCell.swift */; };
 		B96D1C3F227333BE0096492B /* GlossaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D1C3E227333BE0096492B /* GlossaryTableViewCell.swift */; };
 		FBCAB466480A05C9E3D694CF /* Pods_Unwrap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1042D2A80E9E96DA0B7C6F35 /* Pods_Unwrap.framework */; };
 /* End PBXBuildFile section */
@@ -1203,6 +1205,8 @@
 		879EE4E91437B6378BB24AE1 /* Pods-Unwrap.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unwrap.release.xcconfig"; path = "Pods/Target Support Files/Pods-Unwrap/Pods-Unwrap.release.xcconfig"; sourceTree = "<group>"; };
 		AA4718A94B659E9A42AEC33E /* Pods-UnwrapTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnwrapTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnwrapTests/Pods-UnwrapTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B93AEC4A2273DB68005A50DF /* PracticeTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTableViewCell.swift; sourceTree = "<group>"; };
+		B93AEC4C2273DE70005A50DF /* ChallengeTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeTableViewCell.swift; sourceTree = "<group>"; };
+		B93AEC4E2273DF03005A50DF /* PreviousChallengeTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviousChallengeTableViewCell.swift; sourceTree = "<group>"; };
 		B96D1C3E227333BE0096492B /* GlossaryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlossaryTableViewCell.swift; sourceTree = "<group>"; };
 		BB24D72F99ED46CE1F202A82 /* Pods-Unwrap.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unwrap.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Unwrap/Pods-Unwrap.debug.xcconfig"; sourceTree = "<group>"; };
 		BE61552411B754C7764869FE /* Pods-UnwrapUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnwrapUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnwrapUITests/Pods-UnwrapUITests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1558,6 +1562,8 @@
 			children = (
 				5153F49720EF763E009E829D /* ChallengesCoordinator.swift */,
 				51C5642420CCB8350093030C /* ChallengesViewController.swift */,
+				B93AEC4C2273DE70005A50DF /* ChallengeTableViewCell.swift */,
+				B93AEC4E2273DF03005A50DF /* PreviousChallengeTableViewCell.swift */,
 				51862E6C20CE8B980086CD1B /* ChallengesDataSource.swift */,
 				51ADAEA420CE9004000D9DCF /* ChallengeResult.swift */,
 			);
@@ -2896,6 +2902,7 @@
 				514BF46C21E6693100DE1483 /* GlossaryDataSource.swift in Sources */,
 				51862E5A20CE12330086CD1B /* User.swift in Sources */,
 				511FD6A92105E6B00023E92C /* NewsViewController.swift in Sources */,
+				B93AEC4D2273DE70005A50DF /* ChallengeTableViewCell.swift in Sources */,
 				51596DEA20EE04EF00952ADC /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
 				51A4476D210926FE005D8665 /* CountedSet.swift in Sources */,
 				51862E5C20CE13F00086CD1B /* UserTracking.swift in Sources */,
@@ -2923,6 +2930,7 @@
 				51DB1D79222D9648005CB620 /* WrongAnswer.swift in Sources */,
 				51A6D62720E651DA00FB6B46 /* FloatNames.swift in Sources */,
 				51A6D66820E6953100FB6B46 /* CodeErrorType.swift in Sources */,
+				B93AEC4F2273DF03005A50DF /* PreviousChallengeTableViewCell.swift in Sources */,
 				4C8950C42253633F002F9FA6 /* NewsTableViewCell.swift in Sources */,
 				51B87CDE210B35C600FE773A /* User-StaticProperties.swift in Sources */,
 				511FD6B12105F07A0023E92C /* URL-String.swift in Sources */,

--- a/Unwrap/Activities/Challenges/ChallengeTableViewCell.swift
+++ b/Unwrap/Activities/Challenges/ChallengeTableViewCell.swift
@@ -1,0 +1,27 @@
+//
+//  TakeChallengeTableViewCell.swift
+//  Unwrap
+//
+//  Created by Julian Schiavo on 27/4/2019.
+//  Copyright © 2019 Hacking with Swift. All rights reserved.
+//
+
+import UIKit
+
+class ChallengeTableViewCell: UITableViewCell {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+        accessoryType = .disclosureIndicator
+
+        textLabel?.text = "Start"
+        textLabel?.font = .preferredFont(forTextStyle: .title1)
+
+        detailTextLabel?.text = "Each daily challenge may be attempted only once."
+        detailTextLabel?.font = Unwrap.scaledBaseFont
+        detailTextLabel?.numberOfLines = 0
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Unwrap/Activities/Challenges/ChallengesCoordinator.swift
+++ b/Unwrap/Activities/Challenges/ChallengesCoordinator.swift
@@ -30,7 +30,7 @@ class ChallengesCoordinator: Coordinator, Awarding, Skippable, AnswerHandling {
         navigationController.navigationBar.prefersLargeTitles = true
         navigationController.coordinator = self
 
-        let viewController = ChallengesViewController.instantiate()
+        let viewController = ChallengesViewController(style: .grouped)
         viewController.tabBarItem = UITabBarItem(title: "Challenges", image: UIImage(bundleName: "Challenges"), tag: 3)
         viewController.coordinator = self
         navigationController.viewControllers = [viewController]

--- a/Unwrap/Activities/Challenges/ChallengesDataSource.swift
+++ b/Unwrap/Activities/Challenges/ChallengesDataSource.swift
@@ -45,11 +45,14 @@ class ChallengesDataSource: NSObject, UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == 0 {
             if User.current.hasCompletedTodaysChallenge {
-                let cell = tableView.dequeueReusableCell(withIdentifier: "ComeBackTomorrow", for: indexPath)
+                let cell = tableView.dequeueReusableCell(withIdentifier: "Challenge", for: indexPath)
+                cell.accessoryType = .none
                 cell.selectionStyle = .none
+                cell.textLabel?.text = "Come Back Tomorrow"
                 return cell
             } else {
-                let cell = tableView.dequeueReusableCell(withIdentifier: "TakeChallenge", for: indexPath)
+                let cell = tableView.dequeueReusableCell(withIdentifier: "Challenge", for: indexPath)
+                cell.accessoryType = .disclosureIndicator
                 cell.textLabel?.text = Date().formatted
                 return cell
             }

--- a/Unwrap/Activities/Challenges/ChallengesViewController.swift
+++ b/Unwrap/Activities/Challenges/ChallengesViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The main view controller you see in  the Challenges tab in the app.
-class ChallengesViewController: UITableViewController, Storyboarded, UserTracking {
+class ChallengesViewController: UITableViewController, UserTracking {
     var coordinator: ChallengesCoordinator?
 
     /// This handles all the rows in our table view.
@@ -22,7 +22,10 @@ class ChallengesViewController: UITableViewController, Storyboarded, UserTrackin
 
         title = "Challenges"
         registerForUserChanges()
+
         tableView.dataSource = dataSource
+        tableView.register(ChallengeTableViewCell.self, forCellReuseIdentifier: "Challenge")
+        tableView.register(PreviousChallengeTableViewCell.self, forCellReuseIdentifier: "PreviousChallenge")
 
         NotificationCenter.default.addObserver(self, selector: #selector(userDataChanged), name: UIApplication.willEnterForegroundNotification, object: nil)
 

--- a/Unwrap/Activities/Challenges/PreviousChallengeTableViewCell.swift
+++ b/Unwrap/Activities/Challenges/PreviousChallengeTableViewCell.swift
@@ -1,0 +1,22 @@
+//
+//  PreviousChallengeTableViewCell.swift
+//  Unwrap
+//
+//  Created by Julian Schiavo on 27/4/2019.
+//  Copyright © 2019 Hacking with Swift. All rights reserved.
+//
+
+import UIKit
+
+class PreviousChallengeTableViewCell: UITableViewCell {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+        textLabel?.font = Unwrap.scaledBaseFont
+        detailTextLabel?.font = .preferredFont(forTextStyle: .caption1)
+        detailTextLabel?.numberOfLines = 0
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Unwrap/Activities/Home/Help/Credits/CreditsViewController.swift
+++ b/Unwrap/Activities/Home/Help/Credits/CreditsViewController.swift
@@ -8,8 +8,27 @@
 
 import UIKit
 
-class CreditsViewController: UIViewController, Storyboarded {
-    @IBOutlet var textView: UITextView!
+class CreditsViewController: UIViewController {
+    let textView = UITextView()
+
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nil, bundle: nil)
+
+        textView.font = .preferredFont(forTextStyle: .subheadline)
+        textView.isEditable = false
+        textView.dataDetectorTypes = [.link]
+
+        view.addSubview(textView)
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+        textView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+        textView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        textView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Unwrap/Activities/Home/Help/HelpDataSource.swift
+++ b/Unwrap/Activities/Home/Help/HelpDataSource.swift
@@ -36,8 +36,7 @@ class HelpDataSource: NSObject, UITableViewDataSource {
 
         let item = items[indexPath.section]
 
-        // add a couple of line breaks at the end to provide clearer section spacing
-        cell.textView.text = "\(item.text)\n\n"
+        cell.textView.text = item.text
         cell.textView.linkDelegate = delegate
 
         if item.action.isEmpty {

--- a/Unwrap/Activities/Home/Help/HelpTableViewCell.swift
+++ b/Unwrap/Activities/Home/Help/HelpTableViewCell.swift
@@ -9,5 +9,28 @@
 import UIKit
 
 class HelpTableViewCell: UITableViewCell {
-    @IBOutlet var textView: TappableTextView!
+    let textView = TappableTextView()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        textView.font = Unwrap.scaledBaseFont
+
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.dataDetectorTypes = [.link]
+
+        contentView.addSubview(textView)
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor).isActive = true
+        textView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor).isActive = true
+        textView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor).isActive = true
+
+        // Add extra spacing at the bottom of the cell to provide clearer section spacing
+        textView.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor, constant: -20).isActive = true
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 }

--- a/Unwrap/Activities/Home/Help/HelpViewController.swift
+++ b/Unwrap/Activities/Home/Help/HelpViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class HelpViewController: UITableViewController, Storyboarded, TappableTextViewDelegate {
+class HelpViewController: UITableViewController, TappableTextViewDelegate {
     var coordinator: HomeCoordinator?
     var dataSource = HelpDataSource()
 
@@ -23,6 +23,9 @@ class HelpViewController: UITableViewController, Storyboarded, TappableTextViewD
 
         tableView.dataSource = dataSource
         dataSource.delegate = self
+
+        tableView.separatorStyle = .none
+        tableView.register(HelpTableViewCell.self, forCellReuseIdentifier: "Cell")
     }
 
     func linkTapped(_ url: URL) {

--- a/Unwrap/Activities/Home/HomeCoordinator.swift
+++ b/Unwrap/Activities/Home/HomeCoordinator.swift
@@ -52,7 +52,7 @@ class HomeCoordinator: Coordinator, AlertShowing {
 
     /// Show the help screen.
     @objc func showHelp() {
-        let viewController = HelpViewController.instantiate()
+        let viewController = HelpViewController(style: .plain)
         viewController.coordinator = self
         navigationController.pushViewController(viewController, animated: true)
     }

--- a/Unwrap/Activities/Home/HomeCoordinator.swift
+++ b/Unwrap/Activities/Home/HomeCoordinator.swift
@@ -124,7 +124,7 @@ class HomeCoordinator: Coordinator, AlertShowing {
 
     /// Show credits for the app.
     @objc func showCredits() {
-        let credits = CreditsViewController.instantiate()
+        let credits = CreditsViewController()
         navigationController.pushViewController(credits, animated: true)
     }
 }

--- a/Unwrap/Activities/Learn/Glossary/GlossaryTableViewCell.swift
+++ b/Unwrap/Activities/Learn/Glossary/GlossaryTableViewCell.swift
@@ -1,0 +1,23 @@
+//
+//  GlossaryTableViewCell.swift
+//  Unwrap
+//
+//  Created by Julian Schiavo on 26/4/2019.
+//  Copyright © 2019 Hacking with Swift. All rights reserved.
+//
+
+import UIKit
+
+class GlossaryTableViewCell: UITableViewCell {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+
+        textLabel?.font = Unwrap.scaledBoldFont
+        detailTextLabel?.font = .preferredFont(forTextStyle: .caption1)
+        detailTextLabel?.numberOfLines = 0
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Unwrap/Activities/Learn/Glossary/GlossaryViewController.swift
+++ b/Unwrap/Activities/Learn/Glossary/GlossaryViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class GlossaryViewController: UITableViewController, Storyboarded {
+class GlossaryViewController: UITableViewController {
     let dataSource = GlossaryDataSource()
 
     override func viewDidLoad() {
@@ -16,6 +16,12 @@ class GlossaryViewController: UITableViewController, Storyboarded {
 
         title = "Glossary"
         navigationItem.largeTitleDisplayMode = .never
+
         tableView.dataSource = dataSource
+        tableView.register(GlossaryTableViewCell.self, forCellReuseIdentifier: "Cell")
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
     }
 }

--- a/Unwrap/Activities/Learn/LearnCoordinator.swift
+++ b/Unwrap/Activities/Learn/LearnCoordinator.swift
@@ -31,7 +31,7 @@ class LearnCoordinator: Coordinator, Awarding, Skippable, AlertHandling, AnswerH
 
     /// Shows the list of common Swift terms
     func showGlossary() {
-        let vc = GlossaryViewController.instantiate()
+        let vc = GlossaryViewController(style: .plain)
         navigationController.pushViewController(vc, animated: true)
     }
 

--- a/Unwrap/Activities/Learn/LearnCoordinator.swift
+++ b/Unwrap/Activities/Learn/LearnCoordinator.swift
@@ -23,7 +23,7 @@ class LearnCoordinator: Coordinator, Awarding, Skippable, AlertHandling, AnswerH
         navigationController.navigationBar.prefersLargeTitles = true
         navigationController.coordinator = self
 
-        let viewController = LearnViewController.instantiate()
+        let viewController = LearnViewController(style: .plain)
         viewController.tabBarItem = UITabBarItem(title: "Learn", image: UIImage(bundleName: "Learn"), tag: 1)
         viewController.coordinator = self
         navigationController.viewControllers = [viewController]

--- a/Unwrap/Activities/Learn/LearnDataSource.swift
+++ b/Unwrap/Activities/Learn/LearnDataSource.swift
@@ -30,6 +30,7 @@ class LearnDataSource: NSObject, UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+        cell.accessoryType = .disclosureIndicator
 
         let chapter = Unwrap.chapters[indexPath.section]
         let section = chapter.sections[indexPath.row]

--- a/Unwrap/Activities/Learn/LearnViewController.swift
+++ b/Unwrap/Activities/Learn/LearnViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The main view controller you see in  the Home tab in the app.
-class LearnViewController: UITableViewController, Storyboarded, UserTracking, UIViewControllerPreviewingDelegate {
+class LearnViewController: UITableViewController, UserTracking, UIViewControllerPreviewingDelegate {
     var coordinator: LearnCoordinator?
 
     /// This handles all the rows in our table view.
@@ -28,6 +28,8 @@ class LearnViewController: UITableViewController, Storyboarded, UserTracking, UI
         tableView.delegate = dataSource
         registerForPreviewing(with: self, sourceView: tableView)
         dataSource.delegate = self
+
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
     }
 
     /// Refreshes everything when the user changes.

--- a/Unwrap/Activities/News/NewsCoordinator.swift
+++ b/Unwrap/Activities/News/NewsCoordinator.swift
@@ -18,7 +18,7 @@ class NewsCoordinator: Coordinator {
         navigationController.navigationBar.prefersLargeTitles = true
         navigationController.coordinator = self
 
-        let viewController = NewsViewController.instantiate()
+        let viewController = NewsViewController(style: .plain)
         viewController.tabBarItem = UITabBarItem(title: "News", image: UIImage(bundleName: "News"), tag: 4)
         viewController.coordinator = self
 

--- a/Unwrap/Activities/News/NewsTableViewCell.swift
+++ b/Unwrap/Activities/News/NewsTableViewCell.swift
@@ -11,25 +11,126 @@ import UIKit
 /// Represents a row in the News table view that contains an article to read.
 class NewsTableViewCell: UITableViewCell {
     // custom connections for the image view, title, and subtitle
-    @IBOutlet var customImageView: UIImageView!
-    @IBOutlet var customTextLabel: UILabel!
-    @IBOutlet var customDetailTextLabel: UILabel!
+    private let customImageView = UIImageView()
+    private let customTextLabel = UILabel()
+    private let customDetailTextLabel = UILabel()
 
     /// The dot beside the image indicating if the article has been read or not.
-    @IBOutlet weak var readNotification: UILabel!
+    let readNotification = UILabel()
 
-    // send back our custom image view in place of the default image view
+    // Use our custom image view in place of the default image view
     override var imageView: UIImageView? {
         return customImageView
     }
 
-    // send back our custom text label in place of the default text label
+    // Use our custom text label in place of the default text label
     override var textLabel: UILabel? {
         return customTextLabel
     }
 
-    // send back our custom detail text label in place of the default detail text label
+    // Use our custom detail text label in place of the default detail text label
     override var detailTextLabel: UILabel? {
         return customDetailTextLabel
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        accessoryType = .disclosureIndicator
+
+        setupReadNotification()
+        setupImageView()
+        setupLabels()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setupReadNotification() {
+        readNotification.text = "•"
+        readNotification.font = .systemFont(ofSize: 36)
+        readNotification.textColor = UIColor(bundleName: "Primary")
+        readNotification.translatesAutoresizingMaskIntoConstraints = false
+
+        readNotification.setContentHuggingPriority(.required, for: .horizontal)
+        readNotification.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        contentView.addSubview(readNotification)
+
+        NSLayoutConstraint.activate([
+            readNotification.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 5),
+            readNotification.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: -2)
+        ])
+    }
+
+    func setupImageView() {
+        customImageView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(customImageView)
+
+        customImageView.setContentHuggingPriority(UILayoutPriority(251), for: .vertical)
+        customImageView.setContentHuggingPriority(UILayoutPriority(251), for: .horizontal)
+
+        let topAnchor = customImageView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 5)
+        topAnchor.priority = UILayoutPriority(999)
+
+        let bottomAnchor = customImageView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -5)
+        bottomAnchor.priority = UILayoutPriority(999)
+
+        let constraints = [
+            customImageView.widthAnchor.constraint(equalToConstant: 84),
+            customImageView.heightAnchor.constraint(equalToConstant: 56),
+            topAnchor,
+            bottomAnchor,
+            customImageView.leadingAnchor.constraint(equalTo: readNotification.trailingAnchor, constant: 5),
+            customImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+        ]
+        NSLayoutConstraint.activate(constraints)
+    }
+
+    func setupLabels() {
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(containerView)
+
+        customTextLabel.font = Unwrap.scaledBoldFont
+        customTextLabel.numberOfLines = 0
+        customTextLabel.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(customTextLabel)
+
+        customTextLabel.setContentHuggingPriority(.required, for: .vertical)
+        customTextLabel.setContentHuggingPriority(.required, for: .horizontal)
+        customTextLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+
+        let textLabelConstraints = [
+            customTextLabel.topAnchor.constraint(equalTo: containerView.topAnchor),
+            customTextLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            customTextLabel.trailingAnchor.constraint(lessThanOrEqualTo: containerView.trailingAnchor)
+        ]
+
+        customDetailTextLabel.font = .preferredFont(forTextStyle: .caption1)
+        customDetailTextLabel.numberOfLines = 0
+        customDetailTextLabel.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(customDetailTextLabel)
+
+        customDetailTextLabel.setContentHuggingPriority(.required, for: .vertical)
+        customDetailTextLabel.setContentHuggingPriority(.required, for: .horizontal)
+        customDetailTextLabel.setContentCompressionResistancePriority(UILayoutPriority(999), for: .vertical)
+
+        let detailTextLabelConstraints = [
+            customDetailTextLabel.topAnchor.constraint(equalTo: customTextLabel.bottomAnchor, constant: 3),
+            customDetailTextLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            customDetailTextLabel.trailingAnchor.constraint(lessThanOrEqualTo: containerView.trailingAnchor),
+            customDetailTextLabel.bottomAnchor.constraint(lessThanOrEqualTo: containerView.bottomAnchor)
+        ]
+
+        let containerViewConstraints = [
+            containerView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 8),
+            containerView.leadingAnchor.constraint(equalTo: customImageView.trailingAnchor, constant: 8),
+            containerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            containerView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            containerView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -8)
+        ]
+
+        NSLayoutConstraint.activate(textLabelConstraints + detailTextLabelConstraints + containerViewConstraints)
     }
 }

--- a/Unwrap/Activities/News/NewsViewController.swift
+++ b/Unwrap/Activities/News/NewsViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The view controller you see in the News tab in the app.
-class NewsViewController: UITableViewController, Storyboarded, UIViewControllerPreviewingDelegate {
+class NewsViewController: UITableViewController, UIViewControllerPreviewingDelegate {
     var coordinator: NewsCoordinator?
 
     /// This handles all the rows in our table view, including downloading news.
@@ -31,6 +31,7 @@ class NewsViewController: UITableViewController, Storyboarded, UIViewControllerP
 
         dataSource.delegate = self
         tableView.dataSource = dataSource
+        tableView.register(NewsTableViewCell.self, forCellReuseIdentifier: "Cell")
 
         // Configure DZNEmptyDataSource to show a meaningful message when news loading fails. We need to create an empty table footer view to stop separators appearing everywhere.
         tableView.emptyDataSetSource = emptyDataSource

--- a/Unwrap/Activities/Practice/PracticeCoordinator.swift
+++ b/Unwrap/Activities/Practice/PracticeCoordinator.swift
@@ -26,7 +26,7 @@ class PracticeCoordinator: Coordinator, Awarding, Skippable, AnswerHandling {
         navigationController.navigationBar.prefersLargeTitles = true
         navigationController.coordinator = self
 
-        let viewController = PracticeViewController.instantiate()
+        let viewController = PracticeViewController(style: .plain)
         viewController.tabBarItem = UITabBarItem(title: "Practice", image: UIImage(bundleName: "Practice"), tag: 2)
         viewController.coordinator = self
         navigationController.viewControllers = [viewController]

--- a/Unwrap/Activities/Practice/PracticeTableViewCell.swift
+++ b/Unwrap/Activities/Practice/PracticeTableViewCell.swift
@@ -1,0 +1,23 @@
+//
+//  PracticeTableViewCell.swift
+//  Unwrap
+//
+//  Created by Julian Schiavo on 27/4/2019.
+//  Copyright © 2019 Hacking with Swift. All rights reserved.
+//
+
+import UIKit
+
+class PracticeTableViewCell: UITableViewCell {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+
+        textLabel?.font = .preferredFont(forTextStyle: .title1)
+        detailTextLabel?.font = Unwrap.scaledBaseFont
+        detailTextLabel?.numberOfLines = 0
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Unwrap/Activities/Practice/PracticeViewController.swift
+++ b/Unwrap/Activities/Practice/PracticeViewController.swift
@@ -23,6 +23,7 @@ class PracticeViewController: UITableViewController, Storyboarded, UserTracking 
         title = "Practice"
         registerForUserChanges()
         tableView.dataSource = dataSource
+        tableView.register(PracticeTableViewCell.self, forCellReuseIdentifier: "Cell")
     }
 
     /// Refreshes everything when the user changes.

--- a/Unwrap/Activities/Practice/PracticeViewController.swift
+++ b/Unwrap/Activities/Practice/PracticeViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The main view controller you see in  the Practice tab in the app.
-class PracticeViewController: UITableViewController, Storyboarded, UserTracking {
+class PracticeViewController: UITableViewController, UserTracking {
     var coordinator: PracticeCoordinator?
 
     /// This handles all the rows in our table view.

--- a/Unwrap/Base.lproj/Main.storyboard
+++ b/Unwrap/Base.lproj/Main.storyboard
@@ -162,45 +162,6 @@
             </objects>
             <point key="canvasLocation" x="1521" y="753"/>
         </scene>
-        <!--Learn View Controller-->
-        <scene sceneID="lNi-g2-5ey">
-            <objects>
-                <tableViewController storyboardIdentifier="LearnViewController" id="4Uk-lz-H7x" customClass="LearnViewController" customModule="Unwrap" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" id="3t5-l0-WIO">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="Cell" textLabel="98v-R1-GeE" style="IBUITableViewCellStyleDefault" id="PsV-TH-6RG">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PsV-TH-6RG" id="pcf-b5-sgv">
-                                    <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="98v-R1-GeE">
-                                            <rect key="frame" x="15" y="0.0" width="325" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                                <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="4Uk-lz-H7x" id="GjJ-V5-Afs"/>
-                            <outlet property="delegate" destination="4Uk-lz-H7x" id="F9A-Jn-mtB"/>
-                        </connections>
-                    </tableView>
-                    <navigationItem key="navigationItem" id="Jzy-jh-Wia"/>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="zag-Lt-dnX" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2325" y="-465"/>
-        </scene>
         <!--Glossary View Controller-->
         <scene sceneID="ANa-Nm-QoR">
             <objects>
@@ -1020,7 +981,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KMM-zC-LCY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2325" y="-1177"/>
+            <point key="canvasLocation" x="2324" y="-515"/>
         </scene>
         <!--Spot The Error View Controller-->
         <scene sceneID="aXR-Ta-oR7">

--- a/Unwrap/Base.lproj/Main.storyboard
+++ b/Unwrap/Base.lproj/Main.storyboard
@@ -500,53 +500,6 @@
             </objects>
             <point key="canvasLocation" x="2418" y="-1956"/>
         </scene>
-        <!--Help View Controller-->
-        <scene sceneID="OcZ-ZV-QyY">
-            <objects>
-                <tableViewController storyboardIdentifier="HelpViewController" id="Zti-xD-xDe" customClass="HelpViewController" customModule="Unwrap" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ROs-B1-LpG">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" id="r8p-Kq-x2W" customClass="HelpTableViewCell" customModule="Unwrap" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="r8p-Kq-x2W" id="JZp-f9-028">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Text" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="2cY-e1-dhh" customClass="TappableTextView" customModule="Unwrap" customModuleProvider="target">
-                                            <rect key="frame" x="16" y="11" width="343" height="41"/>
-                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                            <dataDetectorType key="dataDetectorTypes" link="YES"/>
-                                        </textView>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstAttribute="bottom" secondItem="2cY-e1-dhh" secondAttribute="bottomMargin" id="CJP-X2-kCo"/>
-                                        <constraint firstItem="2cY-e1-dhh" firstAttribute="leading" secondItem="JZp-f9-028" secondAttribute="leadingMargin" id="Mim-Rb-CUM"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="2cY-e1-dhh" secondAttribute="trailing" id="NNV-VI-H8i"/>
-                                        <constraint firstItem="2cY-e1-dhh" firstAttribute="top" secondItem="JZp-f9-028" secondAttribute="topMargin" id="TcD-n9-F2E"/>
-                                    </constraints>
-                                </tableViewCellContentView>
-                                <connections>
-                                    <outlet property="textView" destination="2cY-e1-dhh" id="EOZ-jQ-8oB"/>
-                                </connections>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="Zti-xD-xDe" id="0HP-EL-ElU"/>
-                            <outlet property="delegate" destination="Zti-xD-xDe" id="pOu-9W-g1d"/>
-                        </connections>
-                    </tableView>
-                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="eLI-uz-9uh" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="665" y="1074"/>
-        </scene>
         <!--Challenges View Controller-->
         <scene sceneID="Ydl-vc-ZqJ">
             <objects>
@@ -638,7 +591,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tmA-wR-6pm" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2325" y="1074"/>
+            <point key="canvasLocation" x="2324" y="1054"/>
         </scene>
         <!--Tour Item View Controller-->
         <scene sceneID="GxJ-r2-jfV">

--- a/Unwrap/Base.lproj/Main.storyboard
+++ b/Unwrap/Base.lproj/Main.storyboard
@@ -115,7 +115,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1520.8" y="59.820089955022496"/>
+            <point key="canvasLocation" x="2417" y="95"/>
         </scene>
         <!--Tour Page View Controller-->
         <scene sceneID="wpD-rz-caF">
@@ -123,7 +123,7 @@
                 <pageViewController autoresizesArchivedViewToFullSize="NO" automaticallyAdjustsScrollViewInsets="NO" transitionStyle="scroll" navigationOrientation="horizontal" spineLocation="none" id="Xij-wE-rVM" customClass="TourPageViewController" customModule="Unwrap" customModuleProvider="target" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="TAI-x8-cug" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1521" y="1422"/>
+            <point key="canvasLocation" x="2417" y="1413"/>
         </scene>
         <!--Tour Host View Controller-->
         <scene sceneID="jui-My-jyT">
@@ -160,7 +160,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="hmV-MM-RTJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1521" y="753"/>
+            <point key="canvasLocation" x="2417" y="740"/>
         </scene>
         <!--Alert View Controller-->
         <scene sceneID="oPI-oB-A5E">
@@ -258,7 +258,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vKJ-Ag-ie8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3111" y="-2621"/>
+            <point key="canvasLocation" x="2417" y="-1252"/>
         </scene>
         <!--Single Select Review View Controller-->
         <scene sceneID="hnC-uA-4VV">
@@ -507,7 +507,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2Ud-Gj-A0k" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1520.8" y="2021.7391304347827"/>
+            <point key="canvasLocation" x="2417" y="2176"/>
         </scene>
         <!--Home View Controller-->
         <scene sceneID="Ib0-lL-07n">
@@ -717,7 +717,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KMM-zC-LCY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2324" y="582"/>
+            <point key="canvasLocation" x="2417" y="-572"/>
         </scene>
         <!--Spot The Error View Controller-->
         <scene sceneID="aXR-Ta-oR7">
@@ -993,7 +993,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="s5r-td-Abh" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3949.5999999999999" y="115.59220389805098"/>
+            <point key="canvasLocation" x="3828" y="95"/>
         </scene>
         <!--Free Coding View Controller-->
         <scene sceneID="0Tf-ZR-0Py">
@@ -1067,96 +1067,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="je3-gD-Mw8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="3108" y="779"/>
-        </scene>
-        <!--News View Controller-->
-        <scene sceneID="hwl-xt-gxS">
-            <objects>
-                <tableViewController storyboardIdentifier="NewsViewController" id="pGg-9J-cXB" customClass="NewsViewController" customModule="Unwrap" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="teF-Zd-wAe">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="Cell" id="1NR-OF-zX6" customClass="NewsTableViewCell" customModule="Unwrap" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1NR-OF-zX6" id="GNJ-k6-RBG">
-                                    <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="•" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6EC-1U-fcV" userLabel="Read Notification">
-                                            <rect key="frame" x="5" y="-2" width="15" height="43.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="36"/>
-                                            <color key="textColor" name="Primary"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hge-Do-qdQ">
-                                            <rect key="frame" x="25" y="-6.5" width="84" height="56.5"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" constant="56" id="KZK-t8-lFy"/>
-                                                <constraint firstAttribute="width" constant="84" id="xLd-pJ-dFg"/>
-                                            </constraints>
-                                        </imageView>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ms3-4j-Cij">
-                                            <rect key="frame" x="117" y="8" width="224" height="27.5"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vqy-wX-YVY">
-                                                    <rect key="frame" x="0.0" y="0.0" width="42" height="20.5"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" verticalCompressionResistancePriority="999" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bKq-J0-J46">
-                                                    <rect key="frame" x="0.0" y="20.5" width="31" height="7"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            <constraints>
-                                                <constraint firstItem="Vqy-wX-YVY" firstAttribute="top" secondItem="ms3-4j-Cij" secondAttribute="top" id="0Ub-Hv-Th6"/>
-                                                <constraint firstItem="bKq-J0-J46" firstAttribute="top" secondItem="Vqy-wX-YVY" secondAttribute="bottom" id="AMO-pa-Mwr"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bKq-J0-J46" secondAttribute="trailing" id="G5p-9h-0rD"/>
-                                                <constraint firstItem="bKq-J0-J46" firstAttribute="leading" secondItem="ms3-4j-Cij" secondAttribute="leading" id="Sfe-5H-8L4"/>
-                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="bKq-J0-J46" secondAttribute="bottom" id="UoZ-KS-ZIt"/>
-                                                <constraint firstItem="Vqy-wX-YVY" firstAttribute="leading" secondItem="ms3-4j-Cij" secondAttribute="leading" id="p3F-Yw-zfn"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Vqy-wX-YVY" secondAttribute="trailing" id="weh-Ms-tpW"/>
-                                            </constraints>
-                                        </view>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstItem="ms3-4j-Cij" firstAttribute="top" relation="greaterThanOrEqual" secondItem="GNJ-k6-RBG" secondAttribute="top" constant="8" id="61I-Wo-sii"/>
-                                        <constraint firstAttribute="trailing" secondItem="ms3-4j-Cij" secondAttribute="trailing" id="8A5-ge-oaR"/>
-                                        <constraint firstItem="6EC-1U-fcV" firstAttribute="centerY" secondItem="GNJ-k6-RBG" secondAttribute="centerY" constant="-2" id="J8X-le-hj4"/>
-                                        <constraint firstItem="hge-Do-qdQ" firstAttribute="top" relation="greaterThanOrEqual" secondItem="GNJ-k6-RBG" secondAttribute="top" priority="999" constant="5" id="Oaj-5A-PsD"/>
-                                        <constraint firstItem="6EC-1U-fcV" firstAttribute="leading" secondItem="GNJ-k6-RBG" secondAttribute="leading" constant="5" id="Wrm-ik-Z9F"/>
-                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="hge-Do-qdQ" secondAttribute="bottom" priority="999" constant="5" id="Ycb-6P-70g"/>
-                                        <constraint firstItem="hge-Do-qdQ" firstAttribute="leading" secondItem="6EC-1U-fcV" secondAttribute="trailing" constant="5" id="ds5-XV-4Pt"/>
-                                        <constraint firstItem="ms3-4j-Cij" firstAttribute="centerY" secondItem="GNJ-k6-RBG" secondAttribute="centerY" id="fmi-2R-AKJ"/>
-                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ms3-4j-Cij" secondAttribute="bottom" constant="8" id="hTm-Bl-a5n"/>
-                                        <constraint firstItem="ms3-4j-Cij" firstAttribute="leading" secondItem="hge-Do-qdQ" secondAttribute="trailing" constant="8" id="k9y-KJ-JSt"/>
-                                        <constraint firstItem="hge-Do-qdQ" firstAttribute="centerY" secondItem="GNJ-k6-RBG" secondAttribute="centerY" id="wj8-qI-onc"/>
-                                    </constraints>
-                                </tableViewCellContentView>
-                                <connections>
-                                    <outlet property="customDetailTextLabel" destination="bKq-J0-J46" id="OAu-Wn-AoR"/>
-                                    <outlet property="customImageView" destination="hge-Do-qdQ" id="6mO-YQ-sYZ"/>
-                                    <outlet property="customTextLabel" destination="Vqy-wX-YVY" id="bM9-eV-dCQ"/>
-                                    <outlet property="readNotification" destination="6EC-1U-fcV" id="VNO-5e-D07"/>
-                                </connections>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="pGg-9J-cXB" id="8oK-y7-Fq6"/>
-                            <outlet property="delegate" destination="pGg-9J-cXB" id="Nw2-dK-bQ5"/>
-                        </connections>
-                    </tableView>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="cRb-7L-eZk" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2324" y="1451"/>
         </scene>
         <!--Rearrange The Lines View Controller-->
         <scene sceneID="XM7-4d-Ms1">

--- a/Unwrap/Base.lproj/Main.storyboard
+++ b/Unwrap/Base.lproj/Main.storyboard
@@ -162,50 +162,6 @@
             </objects>
             <point key="canvasLocation" x="1521" y="753"/>
         </scene>
-        <!--Glossary View Controller-->
-        <scene sceneID="ANa-Nm-QoR">
-            <objects>
-                <tableViewController storyboardIdentifier="GlossaryViewController" id="Q4Y-Fe-j5k" customClass="GlossaryViewController" customModule="Unwrap" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="cXs-3f-uVF">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="hij-FA-uJY" detailTextLabel="Vke-uE-ZMy" style="IBUITableViewCellStyleSubtitle" id="T84-8o-j0M">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="T84-8o-j0M" id="qdM-Ms-0dj">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hij-FA-uJY">
-                                            <rect key="frame" x="16" y="5" width="36.5" height="20.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Vke-uE-ZMy">
-                                            <rect key="frame" x="16" y="25.5" width="44" height="14.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="Q4Y-Fe-j5k" id="h79-r6-Xzq"/>
-                            <outlet property="delegate" destination="Q4Y-Fe-j5k" id="5ln-8W-Ci7"/>
-                        </connections>
-                    </tableView>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="TLN-6q-Gsa" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="3111" y="-3285"/>
-        </scene>
         <!--Alert View Controller-->
         <scene sceneID="oPI-oB-A5E">
             <objects>

--- a/Unwrap/Base.lproj/Main.storyboard
+++ b/Unwrap/Base.lproj/Main.storyboard
@@ -454,99 +454,6 @@
             </objects>
             <point key="canvasLocation" x="2418" y="-1956"/>
         </scene>
-        <!--Challenges View Controller-->
-        <scene sceneID="Ydl-vc-ZqJ">
-            <objects>
-                <tableViewController storyboardIdentifier="ChallengesViewController" id="tsp-tM-OsK" customClass="ChallengesViewController" customModule="Unwrap" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="fKS-ci-EgH">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="TakeChallenge" textLabel="pNq-NA-bel" detailTextLabel="gt0-uV-Tcd" style="IBUITableViewCellStyleSubtitle" id="HeP-96-hpj">
-                                <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="HeP-96-hpj" id="nVP-EX-SNW">
-                                    <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="pNq-NA-bel">
-                                            <rect key="frame" x="16" y="-15" width="54" height="31.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Each daily challenge may be attempted only once." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="gt0-uV-Tcd">
-                                            <rect key="frame" x="16" y="16.5" width="304" height="42.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PreviousChallenge" textLabel="0Oq-xW-BjZ" detailTextLabel="8QH-9P-ACC" style="IBUITableViewCellStyleSubtitle" id="Dme-K7-fH9">
-                                <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Dme-K7-fH9" id="S1R-Br-JSb">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="0Oq-xW-BjZ">
-                                            <rect key="frame" x="16" y="5" width="33.5" height="20.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="8QH-9P-ACC">
-                                            <rect key="frame" x="16" y="25.5" width="44" height="14.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ComeBackTomorrow" textLabel="TnQ-dI-TZ0" detailTextLabel="AcX-wK-Isk" style="IBUITableViewCellStyleSubtitle" id="Co1-QH-qxq">
-                                <rect key="frame" x="0.0" y="143.5" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Co1-QH-qxq" id="EEX-iz-0IK">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Come Back Tomorrow" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="TnQ-dI-TZ0">
-                                            <rect key="frame" x="16" y="-15" width="245.5" height="31.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Each daily challenge may be attempted only once." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="AcX-wK-Isk">
-                                            <rect key="frame" x="16" y="16.5" width="304" height="42.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="tsp-tM-OsK" id="Cbz-K6-dGW"/>
-                            <outlet property="delegate" destination="tsp-tM-OsK" id="hGb-2l-ubt"/>
-                        </connections>
-                    </tableView>
-                    <navigationItem key="navigationItem" id="czB-Ni-kb9"/>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="tmA-wR-6pm" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2324" y="1036"/>
-        </scene>
         <!--Tour Item View Controller-->
         <scene sceneID="GxJ-r2-jfV">
             <objects>
@@ -810,7 +717,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KMM-zC-LCY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2324" y="251"/>
+            <point key="canvasLocation" x="2324" y="582"/>
         </scene>
         <!--Spot The Error View Controller-->
         <scene sceneID="aXR-Ta-oR7">
@@ -1249,7 +1156,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cRb-7L-eZk" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2324" y="1830.1349325337333"/>
+            <point key="canvasLocation" x="2324" y="1451"/>
         </scene>
         <!--Rearrange The Lines View Controller-->
         <scene sceneID="XM7-4d-Ms1">

--- a/Unwrap/Base.lproj/Main.storyboard
+++ b/Unwrap/Base.lproj/Main.storyboard
@@ -260,52 +260,6 @@
             </objects>
             <point key="canvasLocation" x="3111" y="-2621"/>
         </scene>
-        <!--Practice View Controller-->
-        <scene sceneID="MUM-0w-LqM">
-            <objects>
-                <tableViewController storyboardIdentifier="PracticeViewController" id="b9S-Qg-eJF" customClass="PracticeViewController" customModule="Unwrap" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Rjr-rx-MM3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="YSR-wq-aHE" detailTextLabel="CsI-pE-buB" style="IBUITableViewCellStyleSubtitle" id="pJd-aA-vL4">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pJd-aA-vL4" id="X6X-uo-xhh">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="YSR-wq-aHE">
-                                            <rect key="frame" x="15" y="-4" width="48.5" height="31.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="CsI-pE-buB">
-                                            <rect key="frame" x="15" y="27.5" width="59" height="20.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                                <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="b9S-Qg-eJF" id="JWw-je-bOn"/>
-                            <outlet property="delegate" destination="b9S-Qg-eJF" id="L9d-09-Bvh"/>
-                        </connections>
-                    </tableView>
-                    <navigationItem key="navigationItem" id="dtD-UM-8aa"/>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="iik-Tc-FVi" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2325" y="280"/>
-        </scene>
         <!--Single Select Review View Controller-->
         <scene sceneID="hnC-uA-4VV">
             <objects>
@@ -591,7 +545,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tmA-wR-6pm" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2324" y="1054"/>
+            <point key="canvasLocation" x="2324" y="1036"/>
         </scene>
         <!--Tour Item View Controller-->
         <scene sceneID="GxJ-r2-jfV">
@@ -856,7 +810,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KMM-zC-LCY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2324" y="-515"/>
+            <point key="canvasLocation" x="2324" y="251"/>
         </scene>
         <!--Spot The Error View Controller-->
         <scene sceneID="aXR-Ta-oR7">

--- a/Unwrap/Base.lproj/Main.storyboard
+++ b/Unwrap/Base.lproj/Main.storyboard
@@ -545,41 +545,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eLI-uz-9uh" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="430" y="731"/>
-        </scene>
-        <!--Credits View Controller-->
-        <scene sceneID="0se-w8-pWh">
-            <objects>
-                <viewController storyboardIdentifier="CreditsViewController" id="Gri-KT-vNm" customClass="CreditsViewController" customModule="Unwrap" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="E3G-Pq-GUK">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Credits" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="fkO-fJ-cwM">
-                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                <dataDetectorType key="dataDetectorTypes" link="YES"/>
-                            </textView>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstItem="fkO-fJ-cwM" firstAttribute="leading" secondItem="6UR-gQ-vBU" secondAttribute="leading" id="3fc-Qc-9xT"/>
-                            <constraint firstItem="fkO-fJ-cwM" firstAttribute="top" secondItem="6UR-gQ-vBU" secondAttribute="top" id="Tny-To-JU2"/>
-                            <constraint firstItem="6UR-gQ-vBU" firstAttribute="bottom" secondItem="fkO-fJ-cwM" secondAttribute="bottom" id="c3X-h3-6pY"/>
-                            <constraint firstItem="6UR-gQ-vBU" firstAttribute="trailing" secondItem="fkO-fJ-cwM" secondAttribute="trailing" id="vLa-2R-g6f"/>
-                        </constraints>
-                        <viewLayoutGuide key="safeArea" id="6UR-gQ-vBU"/>
-                    </view>
-                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <connections>
-                        <outlet property="textView" destination="fkO-fJ-cwM" id="onM-ZP-yhI"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="rkk-N0-N39" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="430" y="1406"/>
+            <point key="canvasLocation" x="665" y="1074"/>
         </scene>
         <!--Challenges View Controller-->
         <scene sceneID="Ydl-vc-ZqJ">


### PR DESCRIPTION
This PR switches to creating some of the main, simpler screens programmatically to reduce the size of the storyboard (as per the suggestion in the README).

For now, not all screens have been converted to avoid mistakes or errors.

The following view controllers have been converted:
- `LearnViewController` (Learn tab)
  - `GlossaryViewController` (in the Learn tab)
- `HelpViewController` (within the Home tab)
  - `CreditsViewController` (in HelpViewController)
- `PracticeViewController` (Practice tab)
- `ChallengesViewController` (Challenges tab)
- `NewsViewController` (News tab)