### PR TITLE
Fix scroll view content inset adjustment on certain devices

### DIFF
--- a/Unwrap/Activities/Learn/Study/StudyViewController.swift
+++ b/Unwrap/Activities/Learn/Study/StudyViewController.swift
@@ -27,6 +27,9 @@ class StudyViewController: UIViewController, TappableTextViewDelegate {
 
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Next", style: .plain, target: coordinator, action: #selector(LearnCoordinator.finishedStudying))
+        
+        // always include the safe area insets in the scroll view content adjustment
+        studyTextView.contentInsetAdjustmentBehavior = .always
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
I noticed on certain devices, like the iPhone X, XS and XR that the StudyViewController's scroll view is located under the navigation bar right when it appears. 

This happens, among others, with the "Constants" section on the iPhone XS:

![Screenshot 2019-04-28 at 18 10 38](https://user-images.githubusercontent.com/4272387/56867287-bc59b880-69e3-11e9-9aba-461f26bbce8d.png)

This is the result after the fix (the content no longer appears under the navigation bar):

![Screenshot 2019-04-28 at 18 12 20](https://user-images.githubusercontent.com/4272387/56867297-d4c9d300-69e3-11e9-8da2-97f656d11c75.png)
