### PR TITLE
Bug when being asked a Dictionary question

### DIFF
--- a/Unwrap/Activities/Practice/PredictTheOutput/PredictTheOutput.json
+++ b/Unwrap/Activities/Practice/PredictTheOutput/PredictTheOutput.json
@@ -45,7 +45,7 @@
 	},
 
     {
-        "code": "let RANDOM_STRING_NAMEDict = [String: String]()\nlet selected = allValues[\"test\", default: \"Unknown\"]\nprint(selected)",
+        "code": "let RANDOM_STRING_NAMEDict = [String: String]()\nlet selected = NAME_0Dict.allValues[\"test\", default: \"Unknown\"]\nprint(selected)",
         "answers": [
             {
                 "text": "Unknown"


### PR DESCRIPTION
When resolving the question, `allValues` should be accessed as a variable of the `Dictionary` instance.