### PR TITLE
Improve badges' accessibility

### DIFF
--- a/Unwrap/Activities/Home/BadgeDataSource.swift
+++ b/Unwrap/Activities/Home/BadgeDataSource.swift
@@ -43,13 +43,17 @@ class BadgeDataSource: NSObject, UICollectionViewDataSource, UICollectionViewDel
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let badge = badges[indexPath.item]
-
-        /// Do not perform any action when voice over enabled and Badge is not earned. The accessibilityValue already tells the current progress.
-        if UIAccessibility.isVoiceOverRunning && !User.current.isBadgeEarned(badge) { return }
-
         guard let coordinator = collectionView.findCoordinator() as? HomeCoordinator else { return }
 
-        coordinator.shareBadge(badge)
+        let badge = badges[indexPath.item]
+
+        /// Do not show badge details when voice over is running. For for earned badges we share directly and for not earned the accessibilityValue already tells the current progress.
+        if UIAccessibility.isVoiceOverRunning {
+            if User.current.isBadgeEarned(badge) {
+                coordinator.shareBadge(badge)
+            }
+        } else {
+            coordinator.showBadgeDetails(badge)
+        }
     }
 }

--- a/Unwrap/Activities/Home/BadgeDataSource.swift
+++ b/Unwrap/Activities/Home/BadgeDataSource.swift
@@ -24,20 +24,32 @@ class BadgeDataSource: NSObject, UICollectionViewDataSource, UICollectionViewDel
 
         let badge = badges[indexPath.item]
         cell.imageView.image = badge.image
+        cell.isAccessibilityElement = true
+        cell.accessibilityLabel = "Badge" + badge.name
 
-        /// Highlight earned badges in whatever color was specified in the JSON.
+        /// Highlight earned badges in whatever color was specified in the JSON. Also configures the accessibility values.
         if User.current.isBadgeEarned(badge) {
             cell.imageView.tintColor = UIColor(bundleName: badge.color)
+            cell.accessibilityTraits = .button
+            cell.accessibilityValue = "Earned"
+            cell.accessibilityHint = "Share Badge"
         } else {
             cell.imageView.tintColor = UIColor(bundleName: "Locked")
+            cell.accessibilityTraits = .none
+            cell.accessibilityValue = User.current.badgeProgress(badge).string
         }
 
         return cell
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let coordinator = collectionView.findCoordinator() as? HomeCoordinator else { return }
         let badge = badges[indexPath.item]
+
+        /// Do not perform any action when voice over enabled and Badge is not earned. The accessibilityValue already tells the current progress.
+        if UIAccessibility.isVoiceOverRunning && !User.current.isBadgeEarned(badge) { return }
+
+        guard let coordinator = collectionView.findCoordinator() as? HomeCoordinator else { return }
+
         coordinator.shareBadge(badge)
     }
 }

--- a/Unwrap/Activities/Home/BadgeTableViewCell.swift
+++ b/Unwrap/Activities/Home/BadgeTableViewCell.swift
@@ -18,8 +18,10 @@ class BadgeTableViewCell: UITableViewCell, UserTracking {
 
         // although our main table view will get reloaded when user data changes, iOS will reuse this existing cell if it has one and so we must reload it ourselves as needed.
         registerForUserChanges()
-    }
 
+        // By setting accessibility element to false, we allow voiceover to access the elements inside
+        isAccessibilityElement = false
+    }
     func userDataChanged() {
         collectionView.reloadData()
     }

--- a/Unwrap/Activities/Home/HomeCoordinator.swift
+++ b/Unwrap/Activities/Home/HomeCoordinator.swift
@@ -81,32 +81,33 @@ class HomeCoordinator: Coordinator, AlertShowing {
         navigationController.present(alert, animated: true)
     }
 
-    /// Start sharing the a specific badge the user earned, or just show information about it if the badge is not currently earned.
-    func shareBadge(_ badge: Badge) {
+    /// Show a dialog with the badge's description. If the badge has been earned then the dialog has an option to share otherwise the progress is presented.
+    func showBadgeDetails(_ badge: Badge) {
         if User.current.isBadgeEarned(badge) {
-            // This badge is earned, so share it using the system share sheet.
-            showAlert(title: badge.name, body: badge.description, alternateTitle: "Share") {
-                let image = badge.image.imageForSharing
-                let text = "I earned the badge \(badge.name) in Unwrap by @twostraws. Download it here: \(Unwrap.appURL)"
-
-                let alert = UIActivityViewController(activityItems: [text, image], applicationActivities: nil)
-
-                // if we're on iPad there is nowhere sensible to anchor this from, so just center it
-                if let popOver = alert.popoverPresentationController {
-                    popOver.sourceView = self.navigationController.view
-                    popOver.sourceRect = CGRect(x: self.navigationController.view.frame.midX, y: self.navigationController.view.frame.midY, width: 0, height: 0)
-                }
-
-                self.navigationController.present(alert, animated: true)
+            let body = badge.description.fromSimpleHTML()
+            showAlert(title: badge.name, body: body, alternateTitle: "Share") { [weak self] in
+                self?.shareBadge(badge)
             }
         } else {
-            // This badge isn't earned; just show details about it.
-            let badgeProgress = User.current.badgeProgress(badge)
-            let alert = AlertViewController.instantiate()
-            alert.title = badge.name
-            alert.body = badge.description.centered() + badgeProgress
-            alert.presentAsAlert()
+            let body = badge.description.centered() + User.current.badgeProgress(badge)
+            showAlert(title: badge.name, body: body)
         }
+    }
+
+    /// Share a specific badge the user earned.
+    func shareBadge(_ badge: Badge) {
+        let image = badge.image.imageForSharing
+        let text = "I earned the badge \(badge.name) in Unwrap by @twostraws. Download it here: \(Unwrap.appURL)"
+
+        let alert = UIActivityViewController(activityItems: [text, image], applicationActivities: nil)
+
+        // if we're on iPad there is nowhere sensible to anchor this from, so just center it
+        if let popOver = alert.popoverPresentationController {
+            popOver.sourceView = self.navigationController.view
+            popOver.sourceRect = CGRect(x: self.navigationController.view.frame.midX, y: self.navigationController.view.frame.midY, width: 0, height: 0)
+        }
+
+        self.navigationController.present(alert, animated: true)
     }
 
     /// We need to catch them sharing their score successfully, because doing it at least once to Facebook or Twitter unlocks a badge.

--- a/Unwrap/Activities/Home/HomeDataSource.swift
+++ b/Unwrap/Activities/Home/HomeDataSource.swift
@@ -233,9 +233,6 @@ class HomeDataSource: NSObject, UITableViewDataSource {
         /// See the comment for BadgeTableViewCell.applyLayoutWorkaround()
         cell.layoutIfNeeded()
 
-        //Storyboard doesn't override isAccessibilityElement for UITesting, setting it here
-        cell.isAccessibilityElement = true
-
         return cell
     }
 }

--- a/Unwrap/Protocols/AlertShowing.swift
+++ b/Unwrap/Protocols/AlertShowing.swift
@@ -14,10 +14,14 @@ protocol AlertShowing { }
 extension AlertShowing {
     /// This shows an alert message. Note: this a default implementation of showAlert() in the AlertShowing protocol, but it isn't declared in the protocol because we don't want conforming types to provide their own implementation.
     func showAlert(title: String = "Hint", body: String, coordinator: AlertHandling? = nil, alternateTitle: String? = nil, alternateAction: (() -> Void)? = nil) {
+        showAlert(title: title, body: body.fromSimpleHTML(), coordinator: coordinator, alternateTitle: alternateTitle, alternateAction: alternateAction)
+    }
+
+    func showAlert(title: String = "Hint", body: NSAttributedString, coordinator: AlertHandling? = nil, alternateTitle: String? = nil, alternateAction: (() -> Void)? = nil) {
         let alert = AlertViewController.instantiate()
 
         alert.title = title
-        alert.body = body.fromSimpleHTML()
+        alert.body = body
         alert.alternateTitle = alternateTitle
         alert.alternateAction = alternateAction
         alert.coordinator = coordinator


### PR DESCRIPTION
- Enable accessibility for badges.
- Directly share for earned badge when voice over is enabled.
By pass badge details dialog and directly show share when voice
over is enabled for earned badge, since voice over already read
the badge's details.