### PR TITLE
Change word "struct" to "property" in Line 32

### DIFF
--- a/Unwrap/Content/SixtySeconds/looping-summary.json
+++ b/Unwrap/Content/SixtySeconds/looping-summary.json
@@ -54,7 +54,7 @@
         },
         {
             "answer": "var population = 7_500_000_000\nrepeat {\n\tprint(\"More babies have been born.\")\n\tpopulation *= 1.0001\n} while true",
-            "reason": "This attempts to multiple an <code>Int<\/code> by a <code>Double<\/code>."
+            "reason": "This attempts to multiply an <code>Int<\/code> by a <code>Double<\/code>."
         }
     ]
 }

--- a/Unwrap/Content/SixtySeconds/static-properties-and-methods.html
+++ b/Unwrap/Content/SixtySeconds/static-properties-and-methods.html
@@ -29,7 +29,7 @@
 </pre>
 
 <p style="height: 0px; margin-bottom: 0px;"></p>
-<p>Because the <code>classSize</code> struct belongs to the struct itself rather than instances of the struct, we need to read it using <code>Student.classSize</code>:</p>
+<p>Because the <code>classSize</code> property belongs to the struct itself rather than instances of the struct, we need to read it using <code>Student.classSize</code>:</p>
 <pre class="code">
 <p></p>
 <p><span class="function">print</span><span class="punctuation">(</span><span class="builtin">Student</span><span class="punctuation">.</span>classSize<span class="punctuation">)</span></p>


### PR DESCRIPTION
Original text: 
<p>Because the <code>classSize</code> struct belongs to the struct itself rather than instances of the struct, we need to read it using <code>Student.classSize</code>:</p>

"classSize" is described as a static property on this page and is referred to as a struct in line 32.  

It could improve clarity and make more sense if "classSize" is referred to as a property instead of a struct.