### PR TITLE
Solved the swiftlint build run phase issue

### DIFF
--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -2843,7 +2843,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${PODS_ROOT}/SwiftLint/swiftlint\n";
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
There was an issue with the "Run build phase" in build phases of Unwrap target, which failed the build in Xcode 11.3.1 and gave the error "command phasescriptexecution failed with a nonzero exit code". Fixed that.