### PR TITLE
Added Search Functionality to Glossary Screen

### DIFF
--- a/Unwrap/Activities/Learn/Glossary/GlossaryDataSource.swift
+++ b/Unwrap/Activities/Learn/Glossary/GlossaryDataSource.swift
@@ -11,7 +11,7 @@ import UIKit
 /// Loads glossary entries from JSON and displays them grouped alphabetically.
 class GlossaryDataSource: NSObject, UITableViewDataSource, UISearchResultsUpdating {
     weak var delegate: GlossaryViewController?
-    
+
     /// Stores all glossary entries grouped by their first letter
     var sortedEntries = [String: [GlossaryEntry]]()
 
@@ -20,7 +20,7 @@ class GlossaryDataSource: NSObject, UITableViewDataSource, UISearchResultsUpdati
 
     /// Stores all entries from data file, used for filtering table view data during search
     var originalEntries = [GlossaryEntry]()
-    
+
     /// Loads the glossary definitions from JSON and groups them alphabetically
     override init() {
         super.init()
@@ -28,7 +28,8 @@ class GlossaryDataSource: NSObject, UITableViewDataSource, UISearchResultsUpdati
         originalEntries = entries
         createSortedEntriesAndTitles(from: entries)
     }
-    
+
+    /// Creates the sortedEntries dictionary from a given array of GlossaryEntry and creates the section titles String array
     func createSortedEntriesAndTitles(from entries: [GlossaryEntry]) {
         sortedEntries = Dictionary(grouping: entries) { String($0.term.prefix(1)).uppercased() }
         sectionTitles = sortedEntries.keys.sorted()
@@ -63,17 +64,17 @@ class GlossaryDataSource: NSObject, UITableViewDataSource, UISearchResultsUpdati
 
         return cell
     }
-    
+
     func updateSearchResults(for searchController: UISearchController) {
         guard let text = searchController.searchBar.text?.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) else { return }
-        
+
         if text.isEmpty {
             createSortedEntriesAndTitles(from: originalEntries)
-        }else {
+        } else {
             let filteredEntries = originalEntries.filter { return $0.term.lowercased().contains(text) }
             createSortedEntriesAndTitles(from: filteredEntries)
         }
-        
+
         delegate?.searchPerformed(noResults: sectionTitles.isEmpty)
     }
 }

--- a/Unwrap/Activities/Learn/Glossary/GlossaryDataSource.swift
+++ b/Unwrap/Activities/Learn/Glossary/GlossaryDataSource.swift
@@ -9,18 +9,29 @@
 import UIKit
 
 /// Loads glossary entries from JSON and displays them grouped alphabetically.
-class GlossaryDataSource: NSObject, UITableViewDataSource {
+class GlossaryDataSource: NSObject, UITableViewDataSource, UISearchResultsUpdating {
+    weak var delegate: GlossaryViewController?
+    
     /// Stores all glossary entries grouped by their first letter
     var sortedEntries = [String: [GlossaryEntry]]()
 
     /// Stores the alphabetical letters we want to show along the right edge
     var sectionTitles = [String]()
 
+    /// Stores all entries from data file, used for filtering table view data during search
+    var originalEntries = [GlossaryEntry]()
+    
     /// Loads the glossary definitions from JSON and groups them alphabetically
     override init() {
+        super.init()
         let entries = Bundle.main.decode([GlossaryEntry].self, from: "glossary.json")
+        originalEntries = entries
+        createSortedEntriesAndTitles(from: entries)
+    }
+    
+    func createSortedEntriesAndTitles(from entries: [GlossaryEntry]) {
         sortedEntries = Dictionary(grouping: entries) { String($0.term.prefix(1)).uppercased() }
-        sectionTitles = [String](sortedEntries.keys).sorted()
+        sectionTitles = sortedEntries.keys.sorted()
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -51,5 +62,18 @@ class GlossaryDataSource: NSObject, UITableViewDataSource {
         }
 
         return cell
+    }
+    
+    func updateSearchResults(for searchController: UISearchController) {
+        guard let text = searchController.searchBar.text?.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) else { return }
+        
+        if text.isEmpty {
+            createSortedEntriesAndTitles(from: originalEntries)
+        }else {
+            let filteredEntries = originalEntries.filter { return $0.term.lowercased().contains(text) }
+            createSortedEntriesAndTitles(from: filteredEntries)
+        }
+        
+        delegate?.searchPerformed(noResults: sectionTitles.isEmpty)
     }
 }

--- a/Unwrap/Activities/Learn/Glossary/GlossaryViewController.swift
+++ b/Unwrap/Activities/Learn/Glossary/GlossaryViewController.swift
@@ -12,7 +12,7 @@ class GlossaryViewController: UITableViewController {
     let dataSource = GlossaryDataSource()
 
     let noResultsLabel = UILabel()
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -28,18 +28,18 @@ class GlossaryViewController: UITableViewController {
         setupNoResultsLabel()
         setupSearchController()
     }
-    
+
     func setupNoResultsLabel() {
         noResultsLabel.text = "No Results"
         noResultsLabel.font = Unwrap.scaledBoldFont
         noResultsLabel.isHidden = true
-        
+
         view.addSubview(noResultsLabel)
         noResultsLabel.translatesAutoresizingMaskIntoConstraints = false
         noResultsLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30).isActive = true
         noResultsLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
     }
-    
+
     func setupSearchController() {
         let searchController = UISearchController(searchResultsController: nil)
         searchController.searchResultsUpdater = dataSource
@@ -48,7 +48,7 @@ class GlossaryViewController: UITableViewController {
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
     }
-    
+
     func searchPerformed(noResults: Bool) {
         tableView.reloadData()
         noResultsLabel.isHidden = !noResults

--- a/Unwrap/Activities/Learn/Glossary/GlossaryViewController.swift
+++ b/Unwrap/Activities/Learn/Glossary/GlossaryViewController.swift
@@ -11,6 +11,8 @@ import UIKit
 class GlossaryViewController: UITableViewController {
     let dataSource = GlossaryDataSource()
 
+    let noResultsLabel = UILabel()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -18,7 +20,38 @@ class GlossaryViewController: UITableViewController {
         extendedLayoutIncludesOpaqueBars = true
         navigationItem.largeTitleDisplayMode = .never
 
+        dataSource.delegate = self
         tableView.dataSource = dataSource
         tableView.register(GlossaryTableViewCell.self, forCellReuseIdentifier: "Cell")
+        tableView.tableFooterView = UIView() // Remove separator lines when search has no results
+
+        setupNoResultsLabel()
+        setupSearchController()
     }
+    
+    func setupNoResultsLabel() {
+        noResultsLabel.text = "No Results"
+        noResultsLabel.font = Unwrap.scaledBoldFont
+        noResultsLabel.isHidden = true
+        
+        view.addSubview(noResultsLabel)
+        noResultsLabel.translatesAutoresizingMaskIntoConstraints = false
+        noResultsLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30).isActive = true
+        noResultsLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+    }
+    
+    func setupSearchController() {
+        let searchController = UISearchController(searchResultsController: nil)
+        searchController.searchResultsUpdater = dataSource
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.placeholder = "Search"
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = false
+    }
+    
+    func searchPerformed(noResults: Bool) {
+        tableView.reloadData()
+        noResultsLabel.isHidden = !noResults
+    }
+
 }


### PR DESCRIPTION
Added a UISearchController to the navigation bar, the search bar is always visible similar to iOS built-in apps. If no results are found after a search, a simple "No Results" label is displayed on the screen.

![Simulator Screen Shot - iPhone 11 - 2020-02-27 at 18 10 54](https://user-images.githubusercontent.com/19313231/75473139-8501c280-598c-11ea-8f54-ceee39826796.png)

![Simulator Screen Shot - iPhone 11 - 2020-02-27 at 18 12 51](https://user-images.githubusercontent.com/19313231/75473294-c8f4c780-598c-11ea-9e72-1228c0acbf79.png)

![Simulator Screen Shot - iPhone 11 - 2020-02-27 at 18 12 54](https://user-images.githubusercontent.com/19313231/75473300-cabe8b00-598c-11ea-91cd-f5755b439c1f.png)