### PR TITLE
This PR bumping minimum to version 2.3.0

### DIFF
--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -3286,8 +3286,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/maxkonovalov/MKRingProgressView";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.2.3;
+				kind = upToNextMinorVersion;
+				minimumVersion = 2.3.0;
 			};
 		};
 		5F2EF28B26AE36DA008F29E4 /* XCRemoteSwiftPackageReference "Sourceful" */ = {


### PR DESCRIPTION
<img width="1123" alt="126922192-aac75b6a-a87b-42c9-9c1d-aaf96fe43766" src="https://user-images.githubusercontent.com/4116539/129462774-4e435c98-1ac6-4529-a5ee-a46a42cfd623.png">

This PR bumping minimum to version 2.3.0, fixes the Xcode 12 error for MKRingProgressView. 