### PR TITLE
Add ability to reset user progress.

### DIFF
--- a/Unwrap/Activities/Home/Help/Help.json
+++ b/Unwrap/Activities/Home/Help/Help.json
@@ -24,6 +24,11 @@
 		"text": "<p>Tap here to show the introductory tour again.</p>",
 		"action": "showTour"
 	},
+    {
+        "title": "How can I reset my data?",
+        "text": "<p>Tap here to show reset options.</p>",
+        "action": "resetProgress"
+    },
 	{
 		"title": "About this app",
         "text": "<p>I wrote this app to make it easier for everyone to learn and practice Swift. I already wrote a lot of books about Swift – you can find out more at <a href=\"https://www.hackingwithswift.com\">hackingwithswift.com</a> – but this app was designed to be more fun and more interactive, so hopefully you'll find it useful.</p><p>If you'd like to learn how the app was made (it's written in Swift, naturally!), you can download the source code for yourself from <a href=\"https://www.github.com/twostraws/Unwrap\">github.com/twostraws/Unwrap</a>. Contributions are welcome!</p>",

--- a/Unwrap/Activities/Home/Help/HelpDataSource.swift
+++ b/Unwrap/Activities/Home/Help/HelpDataSource.swift
@@ -73,7 +73,8 @@ class HelpDataSource: NSObject, UITableViewDataSource, UITableViewDelegate {
         switch selected.action {
         case "showTour":
             coordinator?.showTour()
-
+        case "resetProgress":
+            coordinator?.showResetProgressOptions()
         default:
             break
         }

--- a/Unwrap/Activities/Home/HomeCoordinator.swift
+++ b/Unwrap/Activities/Home/HomeCoordinator.swift
@@ -57,12 +57,10 @@ class HomeCoordinator: Coordinator, AlertShowing {
         let resetProgressAction = UIAlertAction(title: "Reset", style: .destructive) { _ in
             User.current.resetProgress()
         }
-
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
 
         alert.addAction(resetProgressAction)
         alert.addAction(cancelAction)
-
         navigationController.present(alert, animated: true)
     }
 

--- a/Unwrap/Activities/Home/HomeCoordinator.swift
+++ b/Unwrap/Activities/Home/HomeCoordinator.swift
@@ -50,6 +50,22 @@ class HomeCoordinator: Coordinator, AlertShowing {
         viewController.presentAsAlert()
     }
 
+    /// Show the options to reset user progress.
+    func showResetProgressOptions() {
+        let alert = UIAlertController(title: "Reset data", message: nil, preferredStyle: .alert)
+
+        let resetProgressAction = UIAlertAction(title: "Reset", style: .destructive) { _ in
+            User.current.resetProgress()
+        }
+
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+
+        alert.addAction(resetProgressAction)
+        alert.addAction(cancelAction)
+
+        navigationController.present(alert, animated: true)
+    }
+
     /// Show the help screen.
     @objc func showHelp() {
         let viewController = HelpViewController(style: .plain)

--- a/Unwrap/User/User.swift
+++ b/Unwrap/User/User.swift
@@ -362,4 +362,13 @@ final class User: Codable {
         save()
     }
 
+    /// Reset user progress.
+    func resetProgress() {
+        dailyChallenges.removeAll()
+        practiceSessions = CountedSet<String>()
+        practicePoints = 0
+        reviewedSections.removeAll()
+        learnedSections.removeAll()
+        statusChanged()
+    }
 }

--- a/UnwrapTests/UserTests.swift
+++ b/UnwrapTests/UserTests.swift
@@ -152,4 +152,20 @@ class UserTests: XCTestCase {
         user.updateStreak()
         XCTAssertEqual(user.bestStreak, 25, "Best streak should not be updated")
     }
+
+    /// Testing user data reset.
+    func testResetProgress() {
+        let user = User()
+
+        let result = ChallengeResult(date: Date(), score: 1000)
+        user.dailyChallenges.append(result)
+        user.practiceSessions.insert("Test session")
+        user.practicePoints += 100
+
+        user.resetProgress()
+
+        XCTAssertTrue(user.dailyChallenges.isEmpty, "Daily challenges should be empty.")
+        XCTAssertTrue(user.practiceSessions.isEmpty, "Practice sessions should be empty.")
+        XCTAssertEqual(user.practicePoints, 0, "Practice points should be 0.")
+    }
 }


### PR DESCRIPTION
This PR fixes issue #196

I've added the option to reset the user progress under the Help tab and wrote the unit test to check the `resetProgress` method.