### PR TITLE
Wrapping user-facing strings in NSLocalizedString

### DIFF
--- a/Unwrap/Activities/Awards/AwardPointsViewController.swift
+++ b/Unwrap/Activities/Awards/AwardPointsViewController.swift
@@ -46,8 +46,8 @@ class AwardPointsViewController: UIViewController, Storyboarded {
         assert(coordinator != nil, "You must set a coordinator before presenting this view controller.")
         extendedLayoutIncludesOpaqueBars = true
 
-        totalPoints.title = "TOTAL"
-        earnedPoints.title = "EARNED"
+        totalPoints.title = NSLocalizedString("TOTAL", comment: "")
+        earnedPoints.title = NSLocalizedString("EARNED", comment: "")
 
         // Configure the status view so that it looks good on a white background, and can animate past 100% so that we can rank up without the animation going back to the start.
         statusView.useTemplateImages = true
@@ -59,8 +59,8 @@ class AwardPointsViewController: UIViewController, Storyboarded {
         // Configure two of our title/subtitle labels so users can see points moving from one place to another.
         totalPoints.textColor = .white
         earnedPoints.textColor = .white
-        totalPoints.attributedText = NSAttributedString.makeTitle("TOTAL", subtitle: User.current.totalPoints.formatted)
-        earnedPoints.attributedText = NSAttributedString.makeTitle("EARNED", subtitle: pointsToAward.formatted)
+        totalPoints.attributedText = NSAttributedString.makeTitle(NSLocalizedString("TOTAL", comment: ""), subtitle: User.current.totalPoints.formatted)
+        earnedPoints.attributedText = NSAttributedString.makeTitle(NSLocalizedString("EARNED", comment: ""), subtitle: pointsToAward.formatted)
 
         // If we're on iPad, the "Tap to continue" label should not be shown
         if UIDevice.current.userInterfaceIdiom == .pad {

--- a/Unwrap/Activities/Challenges/ChallengeTableViewCell.swift
+++ b/Unwrap/Activities/Challenges/ChallengeTableViewCell.swift
@@ -13,10 +13,10 @@ class ChallengeTableViewCell: UITableViewCell {
         super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
         accessoryType = .disclosureIndicator
 
-        textLabel?.text = "Start"
+        textLabel?.text = NSLocalizedString("Start", comment: "")
         textLabel?.font = .preferredFont(forTextStyle: .title1)
 
-        detailTextLabel?.text = "Each daily challenge may be attempted only once."
+        detailTextLabel?.text = NSLocalizedString("Each daily challenge may be attempted only once.", comment: "")
         detailTextLabel?.font = Unwrap.scaledBaseFont
         detailTextLabel?.numberOfLines = 0
     }

--- a/Unwrap/Activities/Challenges/ChallengesCoordinator.swift
+++ b/Unwrap/Activities/Challenges/ChallengesCoordinator.swift
@@ -40,7 +40,7 @@ class ChallengesCoordinator: Coordinator, Awarding, Skippable, AnswerHandling {
         detailViewController.selectionMode = .challenges
 
         splitViewController.viewControllers = [primaryNavigationController, detailViewController]
-        splitViewController.tabBarItem = UITabBarItem(title: "Challenges", image: UIImage(bundleName: "Challenges"), tag: 3)
+        splitViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Challenges", comment: ""), image: UIImage(bundleName: "Challenges"), tag: 3)
 
         // make this split view controller behave sensibly on iPad
         splitViewController.preferredDisplayMode = .allVisible
@@ -115,14 +115,14 @@ class ChallengesCoordinator: Coordinator, Awarding, Skippable, AnswerHandling {
 
     /// Generates a UIAlertController that lets users skip the current challenge question (if they have skips remaining) or exit the whole challenge.
     func addSkip(then nextAction: @escaping () -> Void) {
-        let alert = UIAlertController(title: "Are you sure?", message: "You can skip only three questions during a challenge, and if you quit you won't be able to take a daily challenge again until tomorrow.\n\nYou have \(skipsRemaining.spelledOut) remaining.", preferredStyle: .alert)
+        let alert = UIAlertController(title: NSLocalizedString("Are you sure?", comment: ""), message: "You can skip only three questions during a challenge, and if you quit you won't be able to take a daily challenge again until tomorrow.\n\nYou have \(skipsRemaining.spelledOut) remaining.", preferredStyle: .alert) //
 
-        let skipAction = UIAlertAction(title: "Skip Question", style: .default) { _ in
+        let skipAction = UIAlertAction(title: NSLocalizedString("Skip Question", comment: ""), style: .default) { _ in
             self.skipsRemaining -= 1
             nextAction()
         }
 
-        let quitAction = UIAlertAction(title: "End Challenge", style: .destructive) { _ in
+        let quitAction = UIAlertAction(title: NSLocalizedString("End Challenge", comment: ""), style: .destructive) { _ in
             // immediately score today's challenge as zero so they can't retake
             User.current.completedChallenge(score: 0)
 
@@ -130,7 +130,7 @@ class ChallengesCoordinator: Coordinator, Awarding, Skippable, AnswerHandling {
             self.returnToStart(activityType: .challenges)
         }
 
-        let continueAction = UIAlertAction(title: "Continue", style: .cancel)
+        let continueAction = UIAlertAction(title: NSLocalizedString("Continue", comment: ""), style: .cancel)
 
         if skipsRemaining > 0 {
             // Only add the skip action if they still have skips available.
@@ -144,7 +144,7 @@ class ChallengesCoordinator: Coordinator, Awarding, Skippable, AnswerHandling {
 
     /// Called from the main Challenges table view so that users can share their scores with friends online.
     func shareScore(_ challenge: ChallengeResult, from sourceRect: CGRect) {
-        let text = "I scored \(challenge.score) in Unwrap's daily challenge for \(challenge.date.formatted). Download it here: \(Unwrap.appURL) (via @twostraws)"
+        let text = String.localizedStringWithFormat(NSLocalizedString("I scored %d in Unwrap's daily challenge for %s. Download it here: %s (via @twostraws)", comment: ""), challenge.score, challenge.date.formatted, Unwrap.appURL.absoluteString)
 
         let alert = UIActivityViewController(activityItems: [text], applicationActivities: nil)
 

--- a/Unwrap/Activities/Challenges/ChallengesDataSource.swift
+++ b/Unwrap/Activities/Challenges/ChallengesDataSource.swift
@@ -17,16 +17,16 @@ class ChallengesDataSource: NSObject, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         if section == 0 {
-            return "Today's challenge"
+            return NSLocalizedString("Today's challenge", comment: "")
         } else {
-            return "Previous challenges"
+            return NSLocalizedString("Previous challenges", comment: "")
         }
     }
 
     // This tells users that tapping the date of a previous challenge will share it, because it's not obvious.
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if section == 1 && User.current.dailyChallenges.count > 0 {
-            return "Tap any date to share your score."
+            return NSLocalizedString("Tap any date to share your score.", comment: "")
         }
 
         return nil
@@ -48,7 +48,7 @@ class ChallengesDataSource: NSObject, UITableViewDataSource {
                 let cell = tableView.dequeueReusableCell(withIdentifier: "Challenge", for: indexPath)
                 cell.accessoryType = .none
                 cell.selectionStyle = .none
-                cell.textLabel?.text = "Come Back Tomorrow"
+                cell.textLabel?.text = NSLocalizedString("Come Back Tomorrow", comment: "")
                 return cell
             } else {
                 let cell = tableView.dequeueReusableCell(withIdentifier: "Challenge", for: indexPath)
@@ -60,13 +60,13 @@ class ChallengesDataSource: NSObject, UITableViewDataSource {
             let cell = tableView.dequeueReusableCell(withIdentifier: "PreviousChallenge", for: indexPath)
 
             if User.current.dailyChallenges.isEmpty {
-                cell.textLabel?.text = "No completed challenges yet"
+                cell.textLabel?.text = NSLocalizedString("No completed challenges yet", comment: "")
                 cell.detailTextLabel?.text = nil
                 cell.selectionStyle = .none
             } else {
                 let challenge = User.current.dailyChallenges[indexPath.row]
-                cell.textLabel?.text = "\(challenge.date.formatted)"
-                cell.detailTextLabel?.text = "Score: \(challenge.score)"
+                cell.textLabel?.text = String(challenge.date.formatted)
+                cell.detailTextLabel?.text = .localizedStringWithFormat(NSLocalizedString("Score: %d", comment: ""), challenge.score)
                 cell.selectionStyle = .default
             }
 

--- a/Unwrap/Activities/Challenges/ChallengesViewController.swift
+++ b/Unwrap/Activities/Challenges/ChallengesViewController.swift
@@ -20,7 +20,7 @@ class ChallengesViewController: UITableViewController, UserTracking {
 
         assert(coordinator != nil, "You must set a coordinator before presenting this view controller.")
 
-        title = "Challenges"
+        title = NSLocalizedString("Challenges", comment: "")
         registerForUserChanges()
 
         tableView.dataSource = dataSource

--- a/Unwrap/Activities/Home/BadgeDataSource.swift
+++ b/Unwrap/Activities/Home/BadgeDataSource.swift
@@ -25,14 +25,14 @@ class BadgeDataSource: NSObject, UICollectionViewDataSource, UICollectionViewDel
         let badge = badges[indexPath.item]
         cell.imageView.image = badge.image
         cell.isAccessibilityElement = true
-        cell.accessibilityLabel = "Badge" + badge.name
+        cell.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("Badge %s", comment: ""), badge.name)
 
         /// Highlight earned badges in whatever color was specified in the JSON. Also configures the accessibility values.
         if User.current.isBadgeEarned(badge) {
             cell.imageView.tintColor = UIColor(bundleName: badge.color)
             cell.accessibilityTraits = .button
-            cell.accessibilityValue = "Earned"
-            cell.accessibilityHint = "Share Badge"
+            cell.accessibilityValue = NSLocalizedString("Earned", comment: "")
+            cell.accessibilityHint = NSLocalizedString("Share Badge", comment: "")
         } else {
             cell.imageView.tintColor = UIColor(bundleName: "Locked")
             cell.accessibilityTraits = .none

--- a/Unwrap/Activities/Home/Help/Credits/CreditsViewController.swift
+++ b/Unwrap/Activities/Home/Help/Credits/CreditsViewController.swift
@@ -24,7 +24,7 @@ class CreditsViewController: UIViewController, TappableTextViewDelegate {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
-        title = "Credits"
+        title = NSLocalizedString("Credits", comment: "")
         loadCredits()
 	}
 

--- a/Unwrap/Activities/Home/Help/HelpViewController.swift
+++ b/Unwrap/Activities/Home/Help/HelpViewController.swift
@@ -24,7 +24,7 @@ class HelpViewController: UITableViewController, TappableTextViewDelegate {
             navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneTapped))
         }
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Credits", style: .plain, target: self, action: #selector(showCredits))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Credits", comment: ""), style: .plain, target: self, action: #selector(showCredits))
 
         tableView.dataSource = dataSource
         tableView.delegate = dataSource

--- a/Unwrap/Activities/Home/HomeCoordinator.swift
+++ b/Unwrap/Activities/Home/HomeCoordinator.swift
@@ -26,7 +26,7 @@ class HomeCoordinator: Coordinator, AlertShowing {
         navigationController.coordinator = self
 
         let viewController = HomeViewController.instantiate()
-        viewController.tabBarItem = UITabBarItem(title: "Home", image: UIImage(bundleName: "Home"), tag: 0)
+        viewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Home", comment: ""), image: UIImage(bundleName: "Home"), tag: 0)
         viewController.coordinator = self
 
         navigationController.viewControllers = [viewController]
@@ -67,7 +67,7 @@ class HomeCoordinator: Coordinator, AlertShowing {
     /// Start sharing the user's current score.
     func shareScore(from sourceRect: CGRect) {
         let image = User.current.rankImage.imageForSharing
-        let text = "I'm on level \(User.current.rankNumber) in Unwrap by @twostraws. Download it here: \(Unwrap.appURL)"
+        let text = String.localizedStringWithFormat(NSLocalizedString("I'm on level %d in Unwrap by @twostraws. Download it here: %s", comment: ""), User.current.rankNumber, Unwrap.appURL.absoluteString)
 
         let alert = UIActivityViewController(activityItems: [text, image], applicationActivities: nil)
         alert.completionWithItemsHandler = handleScoreSharingResult
@@ -97,7 +97,7 @@ class HomeCoordinator: Coordinator, AlertShowing {
     /// Share a specific badge the user earned.
     func shareBadge(_ badge: Badge) {
         let image = badge.image.imageForSharing
-        let text = "I earned the badge \(badge.name) in Unwrap by @twostraws. Download it here: \(Unwrap.appURL)"
+        let text = String.localizedStringWithFormat(NSLocalizedString("I earned the badge %s in Unwrap by @twostraws. Download it here: %s", comment: ""), badge.name, Unwrap.appURL.absoluteString)
 
         let alert = UIActivityViewController(activityItems: [text, image], applicationActivities: nil)
 

--- a/Unwrap/Activities/Home/HomeDataSource.swift
+++ b/Unwrap/Activities/Home/HomeDataSource.swift
@@ -24,16 +24,16 @@ class HomeDataSource: NSObject, UITableViewDataSource {
             return nil
 
         case 1:
-            return "POINTS"
+            return NSLocalizedString("POINTS", comment: "")
 
         case 2:
-            return "STATS"
+            return NSLocalizedString("STATS", comment: "")
 
         case 3:
-            return "STREAK"
+            return NSLocalizedString("STREAK", comment: "")
 
         case 4:
-            return "BADGES"
+            return NSLocalizedString("BADGES", comment: "")
 
         default:
             fatalError("Unknown table view section: \(section).")
@@ -109,7 +109,7 @@ class HomeDataSource: NSObject, UITableViewDataSource {
     /// Shows the user's total points in large text.
     func makePointsSummary(in tableView: UITableView, indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "Points", for: indexPath)
-        cell.textLabel?.attributedText = NSAttributedString.makeTitle("Points", subtitle: User.current.totalPoints.formatted)
+        cell.textLabel?.attributedText = NSAttributedString.makeTitle(NSLocalizedString("Points", comment: ""), subtitle: User.current.totalPoints.formatted)
         cell.accessibilityLabel = "\(User.current.totalPoints) points"
 
         return cell
@@ -121,27 +121,27 @@ class HomeDataSource: NSObject, UITableViewDataSource {
 
         switch indexPath.row {
         case 0:
-            cell.textLabel?.text = "Learning Points"
+            cell.textLabel?.text = NSLocalizedString("Learning Points", comment: "")
             cell.detailTextLabel?.text = User.current.learnPoints.formatted
-            cell.accessibilityLabel = "\(User.current.learnPoints) points from learning"
+            cell.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("%d points from learning", comment: ""), User.current.learnPoints)
 
         case 1:
-            cell.textLabel?.text = "Review Points"
+            cell.textLabel?.text = NSLocalizedString("Review Points", comment: "")
             cell.detailTextLabel?.text = User.current.reviewPoints.formatted
-            cell.accessibilityLabel = "\(User.current.reviewPoints) points from reviews"
+            cell.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("%d points from reviews", comment: ""), User.current.reviewPoints)
 
         case 2:
-            cell.textLabel?.text = "Practice Points"
+            cell.textLabel?.text = NSLocalizedString("Practice Points", comment: "")
             cell.detailTextLabel?.text = User.current.practicePoints.formatted
-            cell.accessibilityLabel = "\(User.current.practicePoints) points from practicing"
+            cell.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("%d points from practicing", comment: ""), User.current.practicePoints)
 
         case 3:
-            cell.textLabel?.text = "Challenge Points"
+            cell.textLabel?.text = NSLocalizedString("Challenge Points", comment: "")
             cell.detailTextLabel?.text = User.current.challengePoints.formatted
-            cell.accessibilityLabel = "\(User.current.challengePoints) points from challenges"
+            cell.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("%d points from challenges", comment: ""), User.current.challengePoints)
 
         case 4:
-            cell.textLabel?.text = "Share Score"
+            cell.textLabel?.text = NSLocalizedString("Share Score", comment: "")
             cell.accessibilityTraits = .button
             cell.textLabel?.textColor = UIColor(bundleName: "Primary")
 
@@ -158,25 +158,26 @@ class HomeDataSource: NSObject, UITableViewDataSource {
 
         switch indexPath.row {
         case 0:
-            cell.textLabel?.text = "Current Level"
+            cell.textLabel?.text = NSLocalizedString("Current Level", comment: "")
             cell.detailTextLabel?.text = "\(User.current.rankNumber)/21"
-            cell.accessibilityLabel = "You are level \(User.current.rankNumber) of 21."
+            let levels = 21
+            cell.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("You are on level %d of %d.", comment: ""), User.current.rankNumber, levels)
 
         case 1:
-            cell.textLabel?.text = "Points Until Next Level"
+            cell.textLabel?.text = NSLocalizedString("Points Until Next Level", comment: "")
 
             if let points = User.current.pointsUntilNextRank {
                 cell.detailTextLabel?.text = String(points)
-                cell.accessibilityLabel = "You need \(points) more points to reach the next level."
+                cell.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("You need %d more points to reach the next level.", comment: ""), points)
             } else {
-                cell.detailTextLabel?.text = "N/A"
-                cell.accessibilityLabel = "You are at the maximum level."
+                cell.detailTextLabel?.text = NSLocalizedString("N/A", comment: "")
+                cell.accessibilityLabel = NSLocalizedString("You are at the maximum level.", comment: "")
             }
 
         case 2:
-            cell.textLabel?.text = "Daily Challenges"
+            cell.textLabel?.text = NSLocalizedString("Daily Challenges", comment: "")
             cell.detailTextLabel?.text = String(User.current.dailyChallenges.count)
-            cell.accessibilityLabel = "\(User.current.dailyChallenges) daily challenges completed."
+            cell.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("%d daily challenges completed.", comment: ""), User.current.dailyChallenges)
 
         default:
             fatalError("Unknown index path: \(indexPath).")
@@ -190,17 +191,17 @@ class HomeDataSource: NSObject, UITableViewDataSource {
         let cell = dequeueStatReusableCell(in: tableView, indexPath: indexPath)
         switch indexPath.row {
         case 0:
-            cell.textLabel?.text = "Current Streak"
-            cell.detailTextLabel?.text = "\(User.current.streakDays)"
-            cell.accessibilityLabel = "Your streak count is \(User.current.streakDays)"
+            cell.textLabel?.text = NSLocalizedString("Current Streak", comment: "")
+            cell.detailTextLabel?.text = String(User.current.streakDays)
+            cell.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("Your streak count is %d", comment: ""), User.current.streakDays)
             // UITest reading accessibility label and not accessibility identifier in Storyboard
             cell.accessibilityIdentifier = "Streak Reminder"
             return cell
 
         case 1:
-            cell.textLabel?.text = "Best Streak"
+            cell.textLabel?.text = NSLocalizedString("Best Streak", comment: "")
             cell.detailTextLabel?.text = "\(User.current.bestStreak)"
-            cell.accessibilityLabel = "Your best streak count is \(User.current.bestStreak)"
+            cell.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("Your best streak count is %d", comment: ""), User.current.bestStreak)
             // UITest reading accessibility label and not accessibility identifier in Storyboard
             cell.accessibilityIdentifier = "Streak Reminder"
             return cell

--- a/Unwrap/Activities/Home/HomeViewController.swift
+++ b/Unwrap/Activities/Home/HomeViewController.swift
@@ -19,11 +19,11 @@ class HomeViewController: UITableViewController, Storyboarded, UserTracking {
 
         assert(coordinator != nil, "You must set a coordinator before presenting this view controller.")
 
-        title = "Home"
+        title = NSLocalizedString("Home", comment: "")
         registerForUserChanges()
         tableView.dataSource = dataSource
 
-        let helpButton = UIBarButtonItem(title: "Help", style: .plain, target: coordinator, action: #selector(HomeCoordinator.showHelp))
+        let helpButton = UIBarButtonItem(title: NSLocalizedString("Help", comment: ""), style: .plain, target: coordinator, action: #selector(HomeCoordinator.showHelp))
         navigationItem.rightBarButtonItem = helpButton
     }
 

--- a/Unwrap/Activities/Learn/Glossary/GlossaryViewController.swift
+++ b/Unwrap/Activities/Learn/Glossary/GlossaryViewController.swift
@@ -16,7 +16,7 @@ class GlossaryViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = "Glossary"
+        title = NSLocalizedString("Glossary", comment: "")
         extendedLayoutIncludesOpaqueBars = true
         navigationItem.largeTitleDisplayMode = .never
 
@@ -30,7 +30,7 @@ class GlossaryViewController: UITableViewController {
     }
 
     func setupNoResultsLabel() {
-        noResultsLabel.text = "No Results"
+        noResultsLabel.text = NSLocalizedString("No Results", comment: "")
         noResultsLabel.font = Unwrap.scaledBoldFont
         noResultsLabel.isHidden = true
 
@@ -44,7 +44,7 @@ class GlossaryViewController: UITableViewController {
         let searchController = UISearchController(searchResultsController: nil)
         searchController.searchResultsUpdater = dataSource
         searchController.obscuresBackgroundDuringPresentation = false
-        searchController.searchBar.placeholder = "Search"
+        searchController.searchBar.placeholder = NSLocalizedString("Search", comment: "")
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
     }

--- a/Unwrap/Activities/Learn/LearnCoordinator.swift
+++ b/Unwrap/Activities/Learn/LearnCoordinator.swift
@@ -33,7 +33,7 @@ class LearnCoordinator: Coordinator, Awarding, Skippable, AlertHandling, AnswerH
         detailViewController.selectionMode = .learn
 
         splitViewController.viewControllers = [primaryNavigationController, detailViewController]
-        splitViewController.tabBarItem = UITabBarItem(title: "Learn", image: UIImage(bundleName: "Learn"), tag: 1)
+        splitViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Learn", comment: ""), image: UIImage(bundleName: "Learn"), tag: 1)
 
         if #available(iOS 13, *) {
             if splitViewController.traitCollection.userInterfaceIdiom == .phone {

--- a/Unwrap/Activities/Learn/LearnDataSource.swift
+++ b/Unwrap/Activities/Learn/LearnDataSource.swift
@@ -53,19 +53,19 @@ class LearnDataSource: NSObject, UITableViewDataSource, UITableViewDelegate {
             // alignment uniform across the table.
             cell.imageView?.image = UIImage(bundleName: "Check")
             cell.imageView?.alpha = 0
-            cell.textLabel?.accessibilityLabel = "\(section). Section not started"
+            cell.textLabel?.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("%d. Section not started", comment: ""), section)
         } else if score == 100 {
             // They read this chapter but didn't review it.
             cell.imageView?.image = UIImage(bundleName: "Check")
             cell.imageView?.tintColor = UIColor(bundleName: "CoursePartial")
             cell.imageView?.alpha = 1
-            cell.textLabel?.accessibilityLabel = "\(section). Section in progress"
+            cell.textLabel?.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("%d. Section in progress", comment: ""), section)
         } else if score == 200 {
             // They read and reviewed this chapter.
             cell.imageView?.image = UIImage(bundleName: "Check")
             cell.imageView?.tintColor = UIColor(bundleName: "CourseFull")
             cell.imageView?.alpha = 1
-            cell.textLabel?.accessibilityLabel = "\(section). Section completed"
+            cell.textLabel?.accessibilityLabel = .localizedStringWithFormat(NSLocalizedString("%d. Section completed", comment: ""), section)
         }
 
         return cell

--- a/Unwrap/Activities/Learn/LearnViewController.swift
+++ b/Unwrap/Activities/Learn/LearnViewController.swift
@@ -20,8 +20,8 @@ class LearnViewController: UITableViewController, UserTracking, UIViewController
 
         assert(coordinator != nil, "You must set a coordinator before presenting this view controller.")
 
-        title = "Learn"
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Glossary", style: .plain, target: self, action: #selector(showGlossary))
+        title = NSLocalizedString("Learn", comment: "")
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Glossary", comment: ""), style: .plain, target: self, action: #selector(showGlossary))
         registerForUserChanges()
         extendedLayoutIncludesOpaqueBars = true
 

--- a/Unwrap/Activities/Learn/Review/MultipleSelectReviewViewController.swift
+++ b/Unwrap/Activities/Learn/Review/MultipleSelectReviewViewController.swift
@@ -33,7 +33,7 @@ class MultipleSelectReviewViewController: ReviewViewController, Storyboarded {
     }
 
     func getTitle() -> String {
-        return "Review"
+        return NSLocalizedString("Review", comment: "")
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -50,7 +50,7 @@ class MultipleSelectReviewViewController: ReviewViewController, Storyboarded {
             dataSource.isShowingAnswers = true
             tableView.reloadData()
 
-            answerButton.setTitle("CONTINUE", for: .normal)
+            answerButton.setTitle(NSLocalizedString("CONTINUE", comment: ""), for: .normal)
             navigationItem.leftBarButtonItem?.isEnabled = false
         }
     }

--- a/Unwrap/Activities/Learn/Review/ReviewViewController.swift
+++ b/Unwrap/Activities/Learn/Review/ReviewViewController.swift
@@ -25,8 +25,8 @@ class ReviewViewController: UIViewController, PracticingViewController {
     /// Run all our navigation bar code super early to avoid bad animations on iPhone
     func configureNavigation() {
         navigationItem.largeTitleDisplayMode = .never
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Skip", style: .plain, target: self, action: #selector(skip))
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Hint", style: .plain, target: self, action: #selector(hint))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Skip", comment: ""), style: .plain, target: self, action: #selector(skip))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Hint", comment: ""), style: .plain, target: self, action: #selector(hint))
         extendedLayoutIncludesOpaqueBars = true
     }
 

--- a/Unwrap/Activities/Learn/Review/SingleSelectReviewViewController.swift
+++ b/Unwrap/Activities/Learn/Review/SingleSelectReviewViewController.swift
@@ -32,7 +32,7 @@ class SingleSelectReviewViewController: ReviewViewController, Storyboarded {
     /// Run all our navigation bar code super early to avoid bad animations on iPhone
     override func configureNavigation() {
         super.configureNavigation()
-        title = "Review" + (coordinator?.titleSuffix(for: self) ?? "")
+        title = NSLocalizedString("Review", comment: "") + (coordinator?.titleSuffix(for: self) ?? "")
     }
 
     override func viewDidLoad() {
@@ -66,7 +66,7 @@ class SingleSelectReviewViewController: ReviewViewController, Storyboarded {
     func showAnswer(selected: UIButton) {
         isShowingAnswer = true
         navigationItem.leftBarButtonItem?.isEnabled = false
-        selected.setTitle("CONTINUE", for: .normal)
+        selected.setTitle(NSLocalizedString("CONTINUE", comment: ""), for: .normal)
 
         // disable the other button
         if selected == trueButton {

--- a/Unwrap/Activities/Learn/Study/StudyReview.swift
+++ b/Unwrap/Activities/Learn/Study/StudyReview.swift
@@ -34,7 +34,7 @@ struct StudyReview: Decodable {
     /// When set to true syntax highlight this text at runtime; when set to false, just bold <code> blocks;.
     var syntaxHighlighting: Bool
 
-    /// Loads one review filew for a specific chapter
+    /// Loads one review file for a specific chapter
     static func review(for name: String) -> StudyReview {
         var review = Bundle.main.decode(StudyReview.self, from: "\(name).json")
         review.correct = review.correct.shuffled()

--- a/Unwrap/Activities/Learn/Study/StudyViewController.swift
+++ b/Unwrap/Activities/Learn/Study/StudyViewController.swift
@@ -22,7 +22,7 @@ class StudyViewController: UIViewController, TappableTextViewDelegate {
     func configureNavigation() {
         navigationItem.largeTitleDisplayMode = .never
         extendedLayoutIncludesOpaqueBars = true
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Next", style: .plain, target: coordinator, action: #selector(LearnCoordinator.finishedStudying))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Next", comment: ""), style: .plain, target: coordinator, action: #selector(LearnCoordinator.finishedStudying))
 
         // always include the safe area insets in the scroll view content adjustment
         studyTextView.contentInsetAdjustmentBehavior = .always

--- a/Unwrap/Activities/News/NewsCoordinator.swift
+++ b/Unwrap/Activities/News/NewsCoordinator.swift
@@ -32,7 +32,7 @@ class NewsCoordinator: Coordinator {
         detailViewController.selectionMode = .news
 
         splitViewController.viewControllers = [primaryNavigationController, detailViewController]
-        splitViewController.tabBarItem = UITabBarItem(title: "News", image: UIImage(bundleName: "News"), tag: 4)
+        splitViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("News", comment: ""), image: UIImage(bundleName: "News"), tag: 4)
 
         // make this split view controller behave sensibly on iPad
         splitViewController.preferredDisplayMode = .allVisible

--- a/Unwrap/Activities/News/NewsEmptyDataSource.swift
+++ b/Unwrap/Activities/News/NewsEmptyDataSource.swift
@@ -15,13 +15,13 @@ class NewsEmptyDataSource: NSObject, DZNEmptyDataSetSource, DZNEmptyDataSetDeleg
     weak var delegate: NewsViewController?
 
     func title(forEmptyDataSet scrollView: UIScrollView) -> NSAttributedString? {
-        let str = "News"
+        let str = NSLocalizedString("News", comment: "")
         let attrs = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .headline)]
         return NSAttributedString(string: str, attributes: attrs)
     }
 
     func description(forEmptyDataSet scrollView: UIScrollView) -> NSAttributedString? {
-        let str = "We couldn't download the news right now. Please tap the button below to try again."
+        let str = NSLocalizedString("We couldn't download the news right now. Please tap the button below to try again.", comment: "")
         let attrs = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body)]
         return NSAttributedString(string: str, attributes: attrs)
     }
@@ -31,7 +31,7 @@ class NewsEmptyDataSource: NSObject, DZNEmptyDataSetSource, DZNEmptyDataSetDeleg
     }
 
     func buttonTitle(forEmptyDataSet scrollView: UIScrollView, for state: UIControl.State) -> NSAttributedString? {
-        let str = "Try Again"
+        let str = NSLocalizedString("Try Again", comment: "")
         let attrs = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .callout)]
         return NSAttributedString(string: str, attributes: attrs)
     }

--- a/Unwrap/Activities/News/NewsViewController.swift
+++ b/Unwrap/Activities/News/NewsViewController.swift
@@ -26,8 +26,8 @@ class NewsViewController: UITableViewController, UIViewControllerPreviewingDeleg
 
         assert(coordinator != nil, "You must set a coordinator before presenting this view controller.")
 
-        title = "News"
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Buy Swift Books", style: .plain, target: coordinator, action: #selector(NewsCoordinator.buyBooks))
+        title = NSLocalizedString("News", comment: "")
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Buy Swift Books", comment: ""), style: .plain, target: coordinator, action: #selector(NewsCoordinator.buyBooks))
 
         dataSource.delegate = self
         tableView.dataSource = dataSource

--- a/Unwrap/Activities/Practice/FreeCoding/FreeCodingPractice.swift
+++ b/Unwrap/Activities/Practice/FreeCoding/FreeCodingPractice.swift
@@ -22,8 +22,8 @@ struct FreeCodingPractice: PracticeActivity {
     /// An array of possible answers that correctly answer the question.
     var answers: [String]
 
-    static let name = "Free Coding"
-    static let subtitle = "Write code to solve problems"
+    static let name = NSLocalizedString("Free Coding", comment: "")
+    static let subtitle = NSLocalizedString("Write code to solve problems", comment: "")
     static let lockedUntil = "Typecasting"
     static let icon = UIImage(bundleName: "Practice-FreeCoding")
 

--- a/Unwrap/Activities/Practice/FreeCoding/FreeCodingViewController.swift
+++ b/Unwrap/Activities/Practice/FreeCoding/FreeCodingViewController.swift
@@ -36,11 +36,11 @@ class FreeCodingViewController: UIViewController, Storyboarded, PracticingViewCo
 
     /// Run all our navigation bar code super early to avoid bad animations on iPhone
     func configureNavigation() {
-        title = "Free Coding" + (coordinator?.titleSuffix(for: self) ?? "")
+        title = NSLocalizedString("Free Coding", comment: "") + (coordinator?.titleSuffix(for: self) ?? "")
         navigationItem.largeTitleDisplayMode = .never
         extendedLayoutIncludesOpaqueBars = true
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Skip", style: .plain, target: self, action: #selector(skip))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Skip", comment: ""), style: .plain, target: self, action: #selector(skip))
         showHintButton()
     }
 
@@ -72,13 +72,13 @@ class FreeCodingViewController: UIViewController, Storyboarded, PracticingViewCo
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        showFirstTimeAlert(name: "FreeCoding", title: "Tip", message: "Unwrap is able to understand a variety of different solutions to each problem, but it's not perfect. If you enter a valid solution that is not accepted, please let us know so we can add it and make Unwrap better for everyone!")
+        showFirstTimeAlert(name: "FreeCoding", title: NSLocalizedString("Tip", comment: ""), message: NSLocalizedString("Unwrap is able to understand a variety of different solutions to each problem, but it's not perfect. If you enter a valid solution that is not accepted, please let us know so we can add it and make Unwrap better for everyone!", comment: ""))
     }
 
     /// Shows the hint button. This gets called in more than one place, because we replace it with a Done button when the text view is being edited.
     @objc func showHintButton() {
         textView?.contentTextView.resignFirstResponder()
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Hint", style: .plain, target: self, action: #selector(hint))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Hint", comment: ""), style: .plain, target: self, action: #selector(hint))
     }
 
     @objc func hint() {
@@ -112,7 +112,7 @@ class FreeCodingViewController: UIViewController, Storyboarded, PracticingViewCo
 
     /// Give users the choice of trying again or skipping
     func skipOrRetry() {
-        showAlert(title: "That's not quite right!", body: "Check your code carefully, and try going for the simplest solution that works.", coordinator: nil, alternateTitle: nil, alternateAction: nil)
+        showAlert(title: NSLocalizedString("That's not quite right!", comment: ""), body: NSLocalizedString("Check your code carefully, and try going for the simplest solution that works.", comment: ""), coordinator: nil, alternateTitle: nil, alternateAction: nil)
     }
 
     /// Allows users to dismiss the keyboard when they are ready, so they can tap submit

--- a/Unwrap/Activities/Practice/PracticeCoordinator.swift
+++ b/Unwrap/Activities/Practice/PracticeCoordinator.swift
@@ -34,7 +34,7 @@ class PracticeCoordinator: Coordinator, Awarding, Skippable, AnswerHandling, Ale
 
         // Set up the detail view controller
         splitViewController.viewControllers = [primaryNavigationController, PleaseSelectViewController.instantiate()]
-        splitViewController.tabBarItem = UITabBarItem(title: "Practice", image: UIImage(bundleName: "Practice"), tag: 2)
+        splitViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Practice", comment: ""), image: UIImage(bundleName: "Practice"), tag: 2)
 
         if #available(iOS 13, *) {
             if splitViewController.traitCollection.userInterfaceIdiom == .phone {
@@ -52,7 +52,7 @@ class PracticeCoordinator: Coordinator, Awarding, Skippable, AnswerHandling, Ale
     func startPracticing(_ activity: PracticeActivity.Type) -> Bool {
         if activity.isLocked {
             // They can't access this practice activity yet.
-            showAlert(title: "Activity Locked", body: "You need to complete the chapter \"\(activity.lockedUntil)\" before you can practice this.")
+            showAlert(title: NSLocalizedString("Activity Locked", comment: ""), body: "You need to complete the chapter \"\(activity.lockedUntil)\" before you can practice this.") //
 
             if splitViewController.isCollapsed == false {
                 splitViewController.showDetailViewController(PleaseSelectViewController.instantiate(), sender: self)

--- a/Unwrap/Activities/Practice/PracticeDataSource.swift
+++ b/Unwrap/Activities/Practice/PracticeDataSource.swift
@@ -38,7 +38,7 @@ class PracticeDataSource: NSObject, UITableViewDataSource {
         cell.textLabel?.text = activity.name
 
         if activity.isLocked {
-            cell.detailTextLabel?.text = "Complete \"\(activity.lockedUntil)\" to unlock."
+            cell.detailTextLabel?.text = .localizedStringWithFormat(NSLocalizedString("Complete \"%s\" to unlock.", comment: ""), activity.lockedUntil)
             cell.imageView?.image = UIImage(bundleName: "Lock")
             cell.imageView?.tintColor = UIColor(bundleName: "Locked")
             cell.accessoryType = .none

--- a/Unwrap/Activities/Practice/PracticeViewController.swift
+++ b/Unwrap/Activities/Practice/PracticeViewController.swift
@@ -20,7 +20,7 @@ class PracticeViewController: UITableViewController, UserTracking {
 
         assert(coordinator != nil, "You must set a coordinator before presenting this view controller.")
 
-        title = "Practice"
+        title = NSLocalizedString("Practice", comment: "")
         registerForUserChanges()
         tableView.dataSource = dataSource
         tableView.register(PracticeTableViewCell.self, forCellReuseIdentifier: "Cell")

--- a/Unwrap/Activities/Practice/PredictTheOutput/PredictTheOutputPractice.swift
+++ b/Unwrap/Activities/Practice/PredictTheOutput/PredictTheOutputPractice.swift
@@ -11,10 +11,10 @@ import UIKit
 /// The Predict the Output practice activity. Shows users some code and asks them to type in what it will print when run.
 struct PredictTheOutputPractice: PracticeActivity {
     /// The user-facing question the user needs to answer.
-    let question = "What will be printed when this code runs?"
+    let question = NSLocalizedString("What will be printed when this code runs?", comment: "")
 
     /// The user-facing hint giving the user a nudge.
-    let hint = "You need to follow the logic line by line, as if it were running on a real device."
+    let hint = NSLocalizedString("You need to follow the logic line by line, as if it were running on a real device.", comment: "")
 
     /// The user-facing code that should be shown on screen.
     var code = ""
@@ -26,8 +26,8 @@ struct PredictTheOutputPractice: PracticeActivity {
         return process(answer)
     }
 
-    static let name = "Predict the Output"
-    static let subtitle = "Read code then predict the output"
+    static let name = NSLocalizedString("Predict the Output", comment: "")
+    static let subtitle = NSLocalizedString("Read code then predict the output", comment: "")
     static let lockedUntil = "Functions: Summary"
     static let icon = UIImage(bundleName: "Practice-PredictTheOutput")
 

--- a/Unwrap/Activities/Practice/PredictTheOutput/PredictTheOutputViewController.swift
+++ b/Unwrap/Activities/Practice/PredictTheOutput/PredictTheOutputViewController.swift
@@ -35,12 +35,12 @@ class PredictTheOutputViewController: UIViewController, Storyboarded, Practicing
 
     /// Run all our navigation bar code super early to avoid bad animations on iPhone
     func configureNavigation() {
-        title = "Predict the Output" + (coordinator?.titleSuffix(for: self) ?? "")
+        title = NSLocalizedString("Predict the Output", comment: "") + (coordinator?.titleSuffix(for: self) ?? "")
         navigationItem.largeTitleDisplayMode = .never
         extendedLayoutIncludesOpaqueBars = true
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Skip", style: .plain, target: self, action: #selector(skip))
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Hint", style: .plain, target: self, action: #selector(hint))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Skip", comment: ""), style: .plain, target: self, action: #selector(skip))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Hint", comment: ""), style: .plain, target: self, action: #selector(hint))
     }
 
     /// Configures the UI with the correct content for our current activity.
@@ -59,7 +59,7 @@ class PredictTheOutputViewController: UIViewController, Storyboarded, Practicing
 
         // Attach the Submit button directly to the keyboard to make input faster.
         let submitButton = UIButton.primary(frame: CGRect(x: 0, y: 0, width: 50, height: UIButton.primaryButtonHeight))
-        submitButton.setTitle("SUBMIT", for: .normal)
+        submitButton.setTitle(NSLocalizedString("SUBMIT", comment: ""), for: .normal)
         submitButton.addTarget(self, action: #selector(checkAnswer), for: .touchUpInside)
         answerEntry.inputAccessoryView = submitButton
     }
@@ -94,7 +94,7 @@ class PredictTheOutputViewController: UIViewController, Storyboarded, Practicing
             isShowingAnswers = true
 
             navigationItem.leftBarButtonItem?.isEnabled = false
-            answerButton.setTitle("CONTINUE", for: .normal)
+            answerButton.setTitle(NSLocalizedString("CONTINUE", comment: ""), for: .normal)
 
             if isUserCorrect {
                 answerButton.correctAnswer()
@@ -107,7 +107,7 @@ class PredictTheOutputViewController: UIViewController, Storyboarded, Practicing
 
     func addReasonToTitle() {
         let newTopString = NSMutableAttributedString(attributedString: "\(practiceData.question)\n\n".fromSimpleHTML())
-        let newBottomString = "This code will print \"\(practiceData.correctAnswer)\".".fromSimpleHTML().formattedAsExplanation()
+        let newBottomString = String.localizedStringWithFormat(NSLocalizedString("This code will print \"%s\".", comment: ""), practiceData.correctAnswer).fromSimpleHTML().formattedAsExplanation()
 
         newTopString.append(newBottomString)
         prompt.attributedText = newTopString

--- a/Unwrap/Activities/Practice/RearrangeTheLines/RearrangeTheLinesPractice.swift
+++ b/Unwrap/Activities/Practice/RearrangeTheLines/RearrangeTheLinesPractice.swift
@@ -19,8 +19,8 @@ struct RearrangeTheLinesPractice: PracticeActivity {
     /// The user-facing code that should be shown on screen, line by line, in the correct order.
     var code: [String]
 
-    static let name = "Rearrange the Lines"
-    static let subtitle = "Rearrange code to make it build"
+    static let name = NSLocalizedString("Rearrange the Lines", comment: "")
+    static let subtitle = NSLocalizedString("Rearrange code to make it build", comment: "")
     static let lockedUntil = "Mutability"
     static let icon = UIImage(bundleName: "Practice-RearrangeTheLines")
 

--- a/Unwrap/Activities/Practice/RearrangeTheLines/RearrangeTheLinesViewController.swift
+++ b/Unwrap/Activities/Practice/RearrangeTheLines/RearrangeTheLinesViewController.swift
@@ -33,12 +33,12 @@ class RearrangeTheLinesViewController: UIViewController, Storyboarded, Practicin
 
     /// Run all our navigation bar code super early to avoid bad animations on iPhone
     func configureNavigation() {
-        title = "Rearrange the Lines" + (coordinator?.titleSuffix(for: self) ?? "")
+        title = NSLocalizedString("Rearrange the Lines", comment: "") + (coordinator?.titleSuffix(for: self) ?? "")
         navigationItem.largeTitleDisplayMode = .never
         extendedLayoutIncludesOpaqueBars = true
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Skip", style: .plain, target: self, action: #selector(skip))
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Hint", style: .plain, target: self, action: #selector(hint))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Skip", comment: ""), style: .plain, target: self, action: #selector(skip))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Hint", comment: ""), style: .plain, target: self, action: #selector(hint))
     }
 
     /// Configures the UI with the correct content for our current activity.
@@ -80,7 +80,7 @@ class RearrangeTheLinesViewController: UIViewController, Storyboarded, Practicin
             tableView.reloadData()
 
             navigationItem.leftBarButtonItem?.isEnabled = false
-            answerButton.setTitle("CONTINUE", for: .normal)
+            answerButton.setTitle(NSLocalizedString("CONTINUE", comment: ""), for: .normal)
 
             if practiceData.answerIsCorrect(dataSource.currentCode) {
                 answerButton.correctAnswer()

--- a/Unwrap/Activities/Practice/Review/ReviewMultipleSelectViewController.swift
+++ b/Unwrap/Activities/Practice/Review/ReviewMultipleSelectViewController.swift
@@ -14,6 +14,6 @@ class ReviewMultipleSelectViewController: MultipleSelectReviewViewController {
     }
 
     override func getTitle() -> String {
-        return "Review" + (coordinator?.titleSuffix(for: self) ?? "")
+        return NSLocalizedString("Review", comment: "") + (coordinator?.titleSuffix(for: self) ?? "")
     }
 }

--- a/Unwrap/Activities/Practice/Review/ReviewPractice.swift
+++ b/Unwrap/Activities/Practice/Review/ReviewPractice.swift
@@ -11,8 +11,8 @@ import UIKit
 /// The Free Coding practice activity. Shows users a question and asks them to write Swift code to solve the problem.
 struct ReviewPractice: PracticeActivity {
 
-    static let name = "Review"
-    static let subtitle = "Go over questions you've already learned"
+    static let name = NSLocalizedString("Review", comment: "")
+    static let subtitle = NSLocalizedString("Go over questions you've already learned", comment: "")
     static let lockedUntil = "Variables"
     static let icon = UIImage(bundleName: "Practice-Review")
 

--- a/Unwrap/Activities/Practice/SpotTheError/SpotTheErrorPractice.swift
+++ b/Unwrap/Activities/Practice/SpotTheError/SpotTheErrorPractice.swift
@@ -11,10 +11,10 @@ import UIKit
 /// The Spot the Error practice activity. Shows users some code that contains a single random mistake, and asks them to identify it.
 struct SpotTheErrorPractice: PracticeActivity {
     /// The user-facing question the user needs to answer. This one is always fixed.
-    let question = "Which line of code contains an error?"
+    let question = NSLocalizedString("Which line of code contains an error?", comment: "")
 
     /// The user-facing hint giving the user a nudge. Like the question, this is always fixed.
-    let hint = "If there is an error, it will only be on one line. If you see one line contradict another, the earlier line will always be correct."
+    let hint = NSLocalizedString("If there is an error, it will only be on one line. If you see one line contradict another, the earlier line will always be correct.", comment: "")
 
     /// All user-facing the code lines used in the activity.
     var code = [String]()
@@ -25,8 +25,8 @@ struct SpotTheErrorPractice: PracticeActivity {
     /// The line number containing the error.
     var lineNumber = 0
 
-    static let name = "Spot the Error"
-    static let subtitle = "Master Swift's type system through examples"
+    static let name = NSLocalizedString("Spot the Error", comment: "")
+    static let subtitle = NSLocalizedString("Master Swift's type system through examples", comment: "")
     static let lockedUntil = "Default parameters"
     static let icon = UIImage(bundleName: "Practice-SpotTheError")
 

--- a/Unwrap/Activities/Practice/SpotTheError/SpotTheErrorViewController.swift
+++ b/Unwrap/Activities/Practice/SpotTheError/SpotTheErrorViewController.swift
@@ -33,12 +33,12 @@ class SpotTheErrorViewController: UIViewController, Storyboarded, PracticingView
 
     /// Run all our navigation bar code super early to avoid bad animations on iPhone
     func configureNavigation() {
-        title = "Spot the Error" + (coordinator?.titleSuffix(for: self) ?? "")
+        title = NSLocalizedString("Spot the Error", comment: "") + (coordinator?.titleSuffix(for: self) ?? "")
         navigationItem.largeTitleDisplayMode = .never
         extendedLayoutIncludesOpaqueBars = true
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Skip", style: .plain, target: self, action: #selector(skip))
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Hint", style: .plain, target: self, action: #selector(hint))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Skip", comment: ""), style: .plain, target: self, action: #selector(skip))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Hint", comment: ""), style: .plain, target: self, action: #selector(hint))
     }
 
     /// Configures the UI with the correct content for our current activity.
@@ -59,7 +59,7 @@ class SpotTheErrorViewController: UIViewController, Storyboarded, PracticingView
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        showFirstTimeAlert(name: "SpotTheError", title: "Tip", message: "You should mentally run the code from top to bottom, meaning that if line 3 says an integer should be returned and line 10 tries to return a string, line 10 is the wrong one.")
+        showFirstTimeAlert(name: "SpotTheError", title: NSLocalizedString("Tip", comment: ""), message: NSLocalizedString("You should mentally run the code from top to bottom, meaning that if line 3 says an integer should be returned and line 10 tries to return a string, line 10 is the wrong one.", comment: ""))
 
         // warn users there might be more cells to scroll through
         tableView.flashScrollIndicators()
@@ -99,7 +99,7 @@ class SpotTheErrorViewController: UIViewController, Storyboarded, PracticingView
             tableView.reloadData()
 
             navigationItem.leftBarButtonItem?.isEnabled = false
-            answerButton.setTitle("CONTINUE", for: .normal)
+            answerButton.setTitle(NSLocalizedString("CONTINUE", comment: ""), for: .normal)
 
             if dataSource.isUserCorrect {
                 answerButton.correctAnswer()

--- a/Unwrap/Activities/Practice/TapToCode/TapToCodePractice.swift
+++ b/Unwrap/Activities/Practice/TapToCode/TapToCodePractice.swift
@@ -19,8 +19,8 @@ class TapToCodePractice: PracticeActivity {
     // Any code we should show before the user-replaceable code.
     var existingCode: String
 
-    static let name = "Tap to Code"
-    static let subtitle = "Build working code by tapping components"
+    static let name = NSLocalizedString("Tap to Code", comment: "")
+    static let subtitle = NSLocalizedString("Build working code by tapping components", comment: "")
     static let lockedUntil = "Infinite Loops"
     static let icon = UIImage(bundleName: "Practice-TapToCode")
 

--- a/Unwrap/Activities/Practice/TapToCode/TapToCodeViewController.swift
+++ b/Unwrap/Activities/Practice/TapToCode/TapToCodeViewController.swift
@@ -43,12 +43,12 @@ class TapToCodeViewController: UIViewController, Storyboarded, PracticingViewCon
 
     /// Run all our navigation bar code super early to avoid bad animations on iPhone
     func configureNavigation() {
-        title = "Tap to Code" + (coordinator?.titleSuffix(for: self) ?? "")
+        title = NSLocalizedString("Tap to Code", comment: "") + (coordinator?.titleSuffix(for: self) ?? "")
         navigationItem.largeTitleDisplayMode = .never
         extendedLayoutIncludesOpaqueBars = true
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Skip", style: .plain, target: self, action: #selector(skip))
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Hint", style: .plain, target: self, action: #selector(hint))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Skip", comment: ""), style: .plain, target: self, action: #selector(skip))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Hint", comment: ""), style: .plain, target: self, action: #selector(hint))
     }
 
     /// Configures the UI with the correct content for our current activity.
@@ -99,7 +99,7 @@ class TapToCodeViewController: UIViewController, Storyboarded, PracticingViewCon
     }
 
     @objc func hint() {
-        showAlert(body: "All the code components need to be used somewhere – try rearranging them until you're happy.")
+        showAlert(body: NSLocalizedString("All the code components need to be used somewhere – try rearranging them until you're happy.", comment: ""))
     }
 
     @objc func skip() {
@@ -122,11 +122,11 @@ class TapToCodeViewController: UIViewController, Storyboarded, PracticingViewCon
     // Triggered when all the components are used or not, so we can show the correct prompt.
     func updateAnswerButton() {
         if dataSource.readyToCheck {
-            answerButton.setTitle("SUBMIT", for: .normal)
+            answerButton.setTitle(NSLocalizedString("SUBMIT", comment: ""), for: .normal)
             answerButton.backgroundColor = UIColor(bundleName: "Primary")
             answerButton.isEnabled = true
         } else {
-            answerButton.setTitle("USE ALL THE CODE", for: .normal)
+            answerButton.setTitle(NSLocalizedString("USE ALL THE CODE", comment: ""), for: .normal)
             answerButton.backgroundColor = UIColor(bundleName: "PrimaryDisabled")
             answerButton.isEnabled = false
         }

--- a/Unwrap/Activities/Practice/TypeChecker/TypeCheckerPractice.swift
+++ b/Unwrap/Activities/Practice/TypeChecker/TypeCheckerPractice.swift
@@ -18,8 +18,8 @@ struct TypeCheckerPractice: PracticeActivity {
     /// An array of all the possible types.
     var answers = [Answer]()
 
-    static let name = "Type Checker"
-    static let subtitle = "Identify data types more easily"
+    static let name = NSLocalizedString("Type Checker", comment: "")
+    static let subtitle = NSLocalizedString("Identify data types more easily", comment: "")
     static let lockedUntil = "Type annotations"
     static let icon = UIImage(bundleName: "Practice-TypeChecker")
 
@@ -38,9 +38,9 @@ struct TypeCheckerPractice: PracticeActivity {
 
         // Format the question correctly depending on whether the type starts with a vowel.
         if types[0].type.startsWithVowel {
-            question = "Which of these produces an <code>\(types[0].type)</code>?"
+            question = .localizedStringWithFormat(NSLocalizedString("Which of these produces an <code>%s</code>?", comment: ""), types[0].type)
         } else {
-            question = "Which of these produces a <code>\(types[0].type)</code>?"
+            question = .localizedStringWithFormat(NSLocalizedString("Which of these produces a <code>%s</code>?", comment: ""), types[0].type)
         }
 
         let correctAnswers = Int.random(in: 4...6)
@@ -55,7 +55,7 @@ struct TypeCheckerPractice: PracticeActivity {
             let randomType = types.randomElement()!
 
             if randomType.type != correctType {
-                answers.append(Answer(text: randomType.function(), subtitle: "This doesn't have the type you're looking for.", isCorrect: false, isSelected: false))
+                answers.append(Answer(text: randomType.function(), subtitle: NSLocalizedString("This doesn't have the type you're looking for.", comment: ""), isCorrect: false, isSelected: false))
             }
         }
 

--- a/Unwrap/Activities/Practice/TypeChecker/TypeCheckerViewController.swift
+++ b/Unwrap/Activities/Practice/TypeChecker/TypeCheckerViewController.swift
@@ -33,12 +33,12 @@ class TypeCheckerViewController: UIViewController, Storyboarded, PracticingViewC
 
     /// Run all our navigation bar code super early to avoid bad animations on iPhone
     func configureNavigation() {
-        title = "Type Practice" + (coordinator?.titleSuffix(for: self) ?? "")
+        title = NSLocalizedString("Type Practice", comment: "") + (coordinator?.titleSuffix(for: self) ?? "")
         navigationItem.largeTitleDisplayMode = .never
         extendedLayoutIncludesOpaqueBars = true
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Skip", style: .plain, target: self, action: #selector(skip))
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Hint", style: .plain, target: self, action: #selector(hint))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Skip", comment: ""), style: .plain, target: self, action: #selector(skip))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Hint", comment: ""), style: .plain, target: self, action: #selector(hint))
     }
 
     /// Configures the UI with the correct content for our current activity.
@@ -64,7 +64,7 @@ class TypeCheckerViewController: UIViewController, Storyboarded, PracticingViewC
     }
 
     @objc func hint() {
-        showAlert(body: "Any code without an explicit type will rely on type inference instead.")
+        showAlert(body: NSLocalizedString("Any code without an explicit type will rely on type inference instead.", comment: ""))
     }
 
     @objc func skip() {
@@ -79,7 +79,7 @@ class TypeCheckerViewController: UIViewController, Storyboarded, PracticingViewC
             dataSource.isShowingAnswers = true
             tableView.reloadData()
 
-            answerButton.setTitle("CONTINUE", for: .normal)
+            answerButton.setTitle(NSLocalizedString("CONTINUE", comment: ""), for: .normal)
             navigationItem.leftBarButtonItem?.isEnabled = false
         }
     }

--- a/Unwrap/Activities/Web/WebView.swift
+++ b/Unwrap/Activities/Web/WebView.swift
@@ -106,7 +106,8 @@ class WebView: UIView {
         var shareItems: [Any] = [url]
 
         if let webViewTitle = webView.title {
-            shareItems.append("\(webViewTitle) (via @twostraws)")
+            let twoStraws = "@twostraws"
+            shareItems.append(String.localizedStringWithFormat(NSLocalizedString("%s (via %s)", comment: ""), webViewTitle, twoStraws))
         }
 
         return shareItems

--- a/Unwrap/Activities/Web/WebViewController.swift
+++ b/Unwrap/Activities/Web/WebViewController.swift
@@ -96,7 +96,7 @@ class WebViewController: UIViewController, WKUIDelegate, WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        title = "Failed to load"
+        title = NSLocalizedString("Failed to load", comment: "")
         internalWebView.loadingDidFinish()
         refreshButton?.isEnabled = true
         updateBackForwardState()

--- a/Unwrap/Extensions/BundleLoading.swift
+++ b/Unwrap/Extensions/BundleLoading.swift
@@ -84,9 +84,9 @@ extension String {
         let currentTheme: String
 
         if UIApplication.activeTraitCollection.userInterfaceStyle == .dark {
-            currentTheme = "Dark"
+            currentTheme = NSLocalizedString("Dark", comment: "")
         } else {
-            currentTheme = "Light"
+            currentTheme = NSLocalizedString("Light", comment: "")
         }
 
         var styleContents = String(bundleName: "\(currentTheme)Theme.css")

--- a/Unwrap/Protocols/AlertShowing.swift
+++ b/Unwrap/Protocols/AlertShowing.swift
@@ -13,11 +13,11 @@ protocol AlertShowing { }
 
 extension AlertShowing {
     /// This shows an alert message. Note: this a default implementation of showAlert() in the AlertShowing protocol, but it isn't declared in the protocol because we don't want conforming types to provide their own implementation.
-    func showAlert(title: String = "Hint", body: String, coordinator: AlertHandling? = nil, alternateTitle: String? = nil, alternateAction: (() -> Void)? = nil) {
+    func showAlert(title: String = NSLocalizedString("Hint", comment: ""), body: String, coordinator: AlertHandling? = nil, alternateTitle: String? = nil, alternateAction: (() -> Void)? = nil) {
         showAlert(title: title, body: body.fromSimpleHTML(), coordinator: coordinator, alternateTitle: alternateTitle, alternateAction: alternateAction)
     }
 
-    func showAlert(title: String = "Hint", body: NSAttributedString, coordinator: AlertHandling? = nil, alternateTitle: String? = nil, alternateAction: (() -> Void)? = nil) {
+    func showAlert(title: String = NSLocalizedString("Hint", comment: ""), body: NSAttributedString, coordinator: AlertHandling? = nil, alternateTitle: String? = nil, alternateAction: (() -> Void)? = nil) {
         let alert = AlertViewController.instantiate()
 
         alert.title = title

--- a/Unwrap/Reusables/PleaseSelectViewController.swift
+++ b/Unwrap/Reusables/PleaseSelectViewController.swift
@@ -24,20 +24,20 @@ class PleaseSelectViewController: UIViewController, Storyboarded {
 
         switch selectionMode {
         case .learn:
-            prompt.text = "Please select a topic to learn"
+            prompt.text = NSLocalizedString("Please select a topic to learn", comment: "")
 
         case .challenges:
             if User.current.hasCompletedTodaysChallenge {
-                prompt.text = "Come back tomorrow"
+                prompt.text = NSLocalizedString("Come back tomorrow", comment: "")
             } else {
-                prompt.text = "Start today's challenge when you're ready"
+                prompt.text = NSLocalizedString("Start today's challenge when you're ready", comment: "")
             }
 
         case .news:
-            prompt.text = "Please select an article to read"
+            prompt.text = NSLocalizedString("Please select an article to read", comment: "")
 
         case .practice:
-            prompt.text = "Please select a practice activity to begin"
+            prompt.text = NSLocalizedString("Please select a practice activity to begin", comment: "")
 
         default:
             prompt.text = ""

--- a/Unwrap/User/User-Progress.swift
+++ b/Unwrap/User/User-Progress.swift
@@ -39,20 +39,20 @@ extension User {
             }
 
             if awardedScore == 0 {
-                progress = "\n\nYou have not completed anything in this section yet."
+                progress = NSLocalizedString("\n\nYou have not completed anything in this section yet.", comment: "")
             } else {
-                progress = "\n\nYou have completed \(awardedScore / 200) out of \(totalSections) chapters!"
+                progress = .localizedStringWithFormat(NSLocalizedString("\n\nYou have completed %d out of %d chapters!", comment: ""), awardedScore / 200, totalSections)
             }
 
             return progress.centered()
 
         } else if badge.criterion == "practice" {
             if practiceSessions.count(for: badge.value) < 1 {
-                progress = "\n\nYou have not practiced with this yet."
+                progress = NSLocalizedString("\n\nYou have not practiced with this yet.", comment: "")
             } else if practiceSessions.count(for: badge.value) == 1 {
-                progress = "\n\nYou have practiced \(practiceSessions.count(for: badge.value)) time!"
+                progress = .localizedStringWithFormat(NSLocalizedString("\n\nYou have practiced %d time!", comment: ""), practiceSessions.count(for: badge.value))
             } else {
-                progress = "\n\nYou have practiced \(practiceSessions.count(for: badge.value)) times!"
+                progress = .localizedStringWithFormat(NSLocalizedString("\n\nYou have practiced %d times!", comment: ""), practiceSessions.count(for: badge.value))
             }
 
             return progress.centered()
@@ -60,42 +60,42 @@ extension User {
             switch badge.criterion {
             case "streak":
                 if bestStreak == 1 {
-                    progress = "\n\nYou have only played one day."
+                    progress = NSLocalizedString("\n\nYou have only played one day.", comment: "")
                 } else {
-                    progress = "\n\nYour best streak is \(bestStreak) days!"
+                    progress = .localizedStringWithFormat(NSLocalizedString("\n\nYour best streak is %d days!", comment: ""), bestStreak)
                 }
 
                 return progress.centered()
 
             case "challenge":
                 if dailyChallenges.count < 1 {
-                    progress = "\n\nYou have not completed any challenges yet."
+                    progress = NSLocalizedString("\n\nYou have not completed any challenges yet.", comment: "")
                 } else if dailyChallenges.count == 1 {
-                    progress = "\n\nYou have completed \(dailyChallenges.count) challenge!"
+                    progress = .localizedStringWithFormat(NSLocalizedString("\n\nYou have completed %d challenge!", comment: ""), dailyChallenges.count)
                 } else {
-                    progress = "\n\nYou have completed \(dailyChallenges.count) challenges!"
+                    progress = .localizedStringWithFormat(NSLocalizedString("\n\nYou have completed %d challenges!", comment: ""), dailyChallenges.count)
                 }
 
                 return progress.centered()
 
             case "news":
                 if readNewsCount < 1 {
-                    progress = "\n\nYou have not read any news articles yet."
+                    progress = NSLocalizedString("\n\nYou have not read any news articles yet.", comment: "")
                 } else if readNewsCount == 1 {
-                    progress = "\n\nYou have read \(readNewsCount) news article!"
+                    progress = .localizedStringWithFormat(NSLocalizedString("\n\nYou have read %d news article!", comment: ""), readNewsCount)
                 } else {
-                    progress = "\n\nYou have read \(readNewsCount) news article!"
+                    progress = .localizedStringWithFormat(NSLocalizedString("\n\nYou have read %d news articles!", comment: ""), readNewsCount)
                 }
 
                 return progress.centered()
 
             case "share":
                 if scoreShareCount < 1 {
-                    progress = "\n\nYou have not shared your score yet."
+                    progress = NSLocalizedString("\n\nYou have not shared your score yet.", comment: "")
                 } else if scoreShareCount == 1 {
-                    progress = "\n\nYou have shared your score \(scoreShareCount) time!"
+                    progress = .localizedStringWithFormat(NSLocalizedString("\n\nYou have shared your score %d time!", comment: ""), scoreShareCount)
                 } else {
-                    progress = "\n\nYou have shared your score \(scoreShareCount) times!"
+                    progress = .localizedStringWithFormat(NSLocalizedString("\n\nYou have shared your score %d times!", comment: ""), scoreShareCount)
                 }
 
                 return progress.centered()

--- a/Unwrap/User/User.swift
+++ b/Unwrap/User/User.swift
@@ -62,7 +62,7 @@ final class User: Codable {
     }
 
     /// Tracks the currently enabled theme.
-    var theme = "Light"
+    var theme = NSLocalizedString("Light", comment: "")
 
     /// Tracks which articles the user has read.
     var articlesRead = Set<URL>()


### PR DESCRIPTION
This pull request wraps user-facing strings in `NSLocalizedString`, so that they could be localized at a later point in time.
Addresses #141.

To note:

- Some strings (particularly, the `lockedUntil` ones) suggest they may be used as identifiers; verify those do not break (and consider refactoring them to use unlocalized identifiers instead).
- Same for the currently enabled theme.
- Actual localization (`.strings` file, actual localizations in another language) are not tackled by this pull request.
- We may want to consider unifying capitalization in words, and changing case using `.uppercased()` so duplication based on case is not required.
- We may want to consider looking into `.stringsdict` for pluralization rather than "duplicating" the strings.
- This pull request does not add comments for localized strings.