### PR TITLE
Update AwardPointsViewController.swift

### DIFF
--- a/Unwrap/Activities/Awards/AwardPointsViewController.swift
+++ b/Unwrap/Activities/Awards/AwardPointsViewController.swift
@@ -84,7 +84,7 @@ class AwardPointsViewController: UIViewController, Storyboarded {
         }
 
         totalPoints.count(start: User.current.totalPoints, end: User.current.totalPoints + pointsToAward)
-        earnedPoints.count(start: pointsToAward, end: 0)
+        earnedPoints.count(start: 0, end: pointsToAward)
 
         if levelUpOccurred {
             // We're going to trigger a gentle vibration.


### PR DESCRIPTION
Currently, the awarded points "Earned Points" label located in the "Your Progress" view (the Award Points View Controller) counts down to zero when a Daily Challenge is completed.  The countdown happens quite quickly and can be a little bit disconcerting if your attention is drawn away from the app while the total score is increased by the earned points leaving the Earned value at zero.  Switching the values in the call to CountingLabel.count(start: , end: ) where 0 and pointsToAward are the values for the start and end arguments respectively, allows for the same result in the total.  Additionally, it resolves the situation where the learner is distracted from the "Your Progress" view and wishes to view the "Earned" points value at a later point.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->
  