### PR TITLE
Issue with the badges variable instantiation in method updateSections

### DIFF
--- a/Unwrap.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Unwrap.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,70 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "DZNEmptyDataSet",
+        "repositoryURL": "https://github.com/dzenbot/DZNEmptyDataSet",
+        "state": {
+          "branch": "master",
+          "revision": "9bffa69a83a9fa58a14b3cf43cb6dd8a63774179",
+          "version": null
+        }
+      },
+      {
+        "package": "MKRingProgressView",
+        "repositoryURL": "https://github.com/maxkonovalov/MKRingProgressView",
+        "state": {
+          "branch": null,
+          "revision": "660888aab1d2ab0ed7eb9eb53caec12af4955fa7",
+          "version": "2.3.0"
+        }
+      },
+      {
+        "package": "QuickLayout",
+        "repositoryURL": "https://github.com/huri000/QuickLayout",
+        "state": {
+          "branch": null,
+          "revision": "6be62decbe508d8fc8f9dbafc349d05bab03c38b",
+          "version": "3.0.1"
+        }
+      },
+      {
+        "package": "SDWebImage",
+        "repositoryURL": "https://github.com/SDWebImage/SDWebImage",
+        "state": {
+          "branch": null,
+          "revision": "76dd4b49110b8624317fc128e7fa0d8a252018bc",
+          "version": "5.11.1"
+        }
+      },
+      {
+        "package": "Sourceful",
+        "repositoryURL": "https://github.com/twostraws/Sourceful.git",
+        "state": {
+          "branch": null,
+          "revision": "3e3bec0486229f623fdf24455806e8c63b837afd",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftEntryKit",
+        "repositoryURL": "https://github.com/huri000/SwiftEntryKit",
+        "state": {
+          "branch": null,
+          "revision": "c2d42574e4fe4e1f9719843f35add7922942a16b",
+          "version": "1.2.7"
+        }
+      },
+      {
+        "package": "Zephyr",
+        "repositoryURL": "https://github.com/ArtSabintsev/Zephyr",
+        "state": {
+          "branch": null,
+          "revision": "681a4c68966a20fde9ec27f2e8c7274c107ec535",
+          "version": "3.6.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Unwrap/Activities/Challenges/ChallengesDataSource.swift
+++ b/Unwrap/Activities/Challenges/ChallengesDataSource.swift
@@ -75,14 +75,14 @@ class ChallengesDataSource: NSObject, UITableViewDataSource {
     }
     /// Swipe to delete
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        if indexPath.section == 1 && User.current.dailyChallenges.count > 0{
+        if indexPath.section == 1 && User.current.dailyChallenges.count > 0 {
             return true
-        }else{
+        } else {
             return false
         }
     }
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-            if editingStyle == .delete{
+            if editingStyle == .delete {
                 User.current.dailyChallenges.remove(at: indexPath.row)
                 tableView.reloadData()
                 User.current.save()

--- a/Unwrap/Activities/Home/HomeDataSource.swift
+++ b/Unwrap/Activities/Home/HomeDataSource.swift
@@ -78,7 +78,10 @@ class HomeDataSource: NSObject, UICollectionViewDataSource {
         let badges = HomeSection(
             title: "BADGES",
             type: .badges,
-            items: Array(repeating: HomeItem(type: .badge), count: badges.count)
+            // Error : "variable used within its own initial value"
+            // Issue: badges was used within its own instanatiation expression
+            // Fix: added self.badges.count instead of badges.count
+            items: Array(repeating: HomeItem(type: .badge), count: self.badges.count)
         )
 
         sections = [status, makeScoreSection(), makeStatsSection(), makeStreakSection(), badges]


### PR DESCRIPTION
The issue with the badges variable instantiation in method updateSections of HomeDataSource.swift resolved

Prior Error:
- badges.count was used to fill count parameter of HomeSection class during badges instantiation
- This was giving "variables used within its own initial value"

Solution:
-Resolved by added self.badges.count instead of badges.count

Device Specification:
XCode: 12.3
Emulator iOS version: 14.3
Swift Version: 5.3.2
