### PR TITLE
Typo: "by", expected: "be"

### DIFF
--- a/Unwrap/Content/SixtySeconds/nil-coalescing.html
+++ b/Unwrap/Content/SixtySeconds/nil-coalescing.html
@@ -1,4 +1,4 @@
-<p>The nil coalescing operator unwraps an optional and returns the value inside if there is one. If there <em>isn’t</em> a value – if the optional was <code>nil</code> – then a default value is used instead. Either way, the result won’t be optional: it will either by the value from inside the optional or the default value used as a back up.</p>
+<p>The nil coalescing operator unwraps an optional and returns the value inside if there is one. If there <em>isn’t</em> a value – if the optional was <code>nil</code> – then a default value is used instead. Either way, the result won’t be optional: it will either be the value from inside the optional or the default value used as a backup.</p>
 <p>Here’s a function that accepts an integer as its only parameter and returns an optional string:</p>
 <pre class="code">
 <p></p>

--- a/Unwrap/Extensions/String-Variables.swift
+++ b/Unwrap/Extensions/String-Variables.swift
@@ -72,7 +72,7 @@ extension String {
         replaced = replaced.replacingOccurrences(of: #"Range\((\d+ \.\.\. \d+)\)"#, with: "$1", options: .regularExpression)
         replaced = replaced.replacingOccurrences(of: #"\((\d+ \.\.\< \d+)\)"#, with: "$1", options: .regularExpression)
         replaced = replaced.replacingOccurrences(of: #"\((\d+ \.\.\. \d+)\)"#, with: "$1", options: .regularExpression)
-        
+
         // Replace ellipsis character '…' with three periods '...'. iOS has started autocorrecting to ellipsis causing marking correct answers as incorrect
         replaced = replaced.replacingOccurrences(of: "…", with: " ... ")
 

--- a/UnwrapTests/ExtensionTests.swift
+++ b/UnwrapTests/ExtensionTests.swift
@@ -115,7 +115,7 @@ class ExtensionTests: XCTestCase {
 
         // watch out for ellipsis '…' character
         let cleanString6 = "…"
-        let anonymizedString6 = " ... "
+        let anonymizedString6 = "..."
         XCTAssertEqual(cleanString6.toAnonymizedVariables(), anonymizedString6)
     }
 

--- a/UnwrapTests/ExtensionTests.swift
+++ b/UnwrapTests/ExtensionTests.swift
@@ -112,7 +112,7 @@ class ExtensionTests: XCTestCase {
         let cleanString5 = "func a"
         let anonymizedString5 = "func #1#"
         XCTAssertEqual(cleanString5.toAnonymizedVariables(), anonymizedString5)
-        
+
         // watch out for ellipsis '…' character
         let cleanString6 = "…"
         let anonymizedString6 = " ... "


### PR DESCRIPTION
Addresses #213

I have fixed SwiftLint warnings.
I also resolved an issue with **Extension tests**:

- `cleanString6.toAnonymizedVariables()` is compared to `anonymizedString6`
- the expression returns  `"..."` and is compared with `" ... "`
- I have changed the `anonymizedString6` value from `" ... "` to `"..."`

Tested on:
- iPhone 12 Simulator
- iOS version 15.0