### PR TITLE
Fix SwiftLint warning Trailing Whitespace Violation

### DIFF
--- a/Unwrap/Extensions/String-Variables.swift
+++ b/Unwrap/Extensions/String-Variables.swift
@@ -72,7 +72,7 @@ extension String {
         replaced = replaced.replacingOccurrences(of: #"Range\((\d+ \.\.\. \d+)\)"#, with: "$1", options: .regularExpression)
         replaced = replaced.replacingOccurrences(of: #"\((\d+ \.\.\< \d+)\)"#, with: "$1", options: .regularExpression)
         replaced = replaced.replacingOccurrences(of: #"\((\d+ \.\.\. \d+)\)"#, with: "$1", options: .regularExpression)
-        
+
         // Replace ellipsis character '…' with three periods '...'. iOS has started autocorrecting to ellipsis causing marking correct answers as incorrect
         replaced = replaced.replacingOccurrences(of: "…", with: " ... ")
 

--- a/UnwrapTests/ExtensionTests.swift
+++ b/UnwrapTests/ExtensionTests.swift
@@ -112,7 +112,7 @@ class ExtensionTests: XCTestCase {
         let cleanString5 = "func a"
         let anonymizedString5 = "func #1#"
         XCTAssertEqual(cleanString5.toAnonymizedVariables(), anonymizedString5)
-        
+
         // watch out for ellipsis '…' character
         let cleanString6 = "…"
         let anonymizedString6 = " ... "


### PR DESCRIPTION
Fx SwiftLint warning Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->
  