### PR TITLE
Fix Xcode 13 error caused by SwiftEntryKit

### DIFF
--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -3287,7 +3287,7 @@
 			repositoryURL = "https://github.com/huri000/SwiftEntryKit";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.2.7;
+				minimumVersion = 2.0.0;
 			};
 		};
 		5F2EF28526AE3634008F29E4 /* XCRemoteSwiftPackageReference "SDWebImage" */ = {

--- a/Unwrap.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Unwrap.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,15 +20,6 @@
         }
       },
       {
-        "package": "QuickLayout",
-        "repositoryURL": "https://github.com/huri000/QuickLayout",
-        "state": {
-          "branch": null,
-          "revision": "6be62decbe508d8fc8f9dbafc349d05bab03c38b",
-          "version": "3.0.1"
-        }
-      },
-      {
         "package": "SDWebImage",
         "repositoryURL": "https://github.com/SDWebImage/SDWebImage",
         "state": {
@@ -51,8 +42,8 @@
         "repositoryURL": "https://github.com/huri000/SwiftEntryKit",
         "state": {
           "branch": null,
-          "revision": "c2d42574e4fe4e1f9719843f35add7922942a16b",
-          "version": "1.2.7"
+          "revision": "5ad36cccf0c4b9fea32f4e9b17a8e38f07563ef0",
+          "version": "2.0.0"
         }
       },
       {


### PR DESCRIPTION
Updated the SwiftEntryKit version to fix the Xcode 13 error. When compiling Unwrap application, I see the error below:

```
'shared' is unavailable in application extensions for iOS: Use view controller-based solutions where appropriate instead.
```

<img width="1206" alt="Screenshot 2021-10-17 at 11 44 13" src="https://user-images.githubusercontent.com/4116539/137619368-486d8fda-2f7a-4a7a-afad-3ecf14647cbb.png">

Note that this was not happening with Xcode 12. It started happening when I updated to Xcode 13.0. 