### PR TITLE
WebViewController: Actually display back/forward/share buttons

### DIFF
--- a/Unwrap/Activities/Web/WebViewController.swift
+++ b/Unwrap/Activities/Web/WebViewController.swift
@@ -55,6 +55,7 @@ class WebViewController: UIViewController, WKUIDelegate, WKNavigationDelegate {
 
         refreshButton = UIBarButtonItem(barButtonSystemItem: .refresh, target: internalWebView, action: #selector(internalWebView.reload))
         navigationItem.setRightBarButton(refreshButton, animated: true)
+		navigationItem.setLeftBarButtonItems(toolbarItems, animated: true)
 
         // All three of these become disabled immediately when page loading starts, so we need the below so they don't start active then immediately deactivate.
         backButton.isEnabled = false

--- a/Unwrap/Activities/Web/WebViewController.swift
+++ b/Unwrap/Activities/Web/WebViewController.swift
@@ -55,7 +55,7 @@ class WebViewController: UIViewController, WKUIDelegate, WKNavigationDelegate {
 
         refreshButton = UIBarButtonItem(barButtonSystemItem: .refresh, target: internalWebView, action: #selector(internalWebView.reload))
         navigationItem.setRightBarButton(refreshButton, animated: true)
-		navigationItem.setLeftBarButtonItems(toolbarItems, animated: true)
+        navigationItem.setLeftBarButtonItems(toolbarItems, animated: true)
 
         // All three of these become disabled immediately when page loading starts, so we need the below so they don't start active then immediately deactivate.
         backButton.isEnabled = false


### PR DESCRIPTION
Upon fixing #232, I discovered it actually was all already in there, so all I did was display the buttons. If there was a reason for not displaying them, please tell me, so I can try to do it right.

Works fine for me in simulator, and no *new* failing tests or linting errors due to my commit.