### PR TITLE
Issue-222: Some question types allowing amending answers before submitting.

### DIFF
--- a/Unwrap/Activities/Practice/RearrangeTheLines/RearrangeTheLinesDataSource.swift
+++ b/Unwrap/Activities/Practice/RearrangeTheLines/RearrangeTheLinesDataSource.swift
@@ -79,7 +79,8 @@ class RearrangeTheLinesDataSource: NSObject, UITableViewDataSource, UITableViewD
 
     /// Make sure all cells are movable, because that's kind of the point of this activity.
     func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        return true
+        /// Added this condition so that user will not able to rearrage the rows after submitting the question. issue-222: https://github.com/twostraws/Unwrap/issues/222
+        return (isShowingAnswers == false)
     }
 
     /// Handle cell moves correctly.


### PR DESCRIPTION
- Added fix for [issue-222](https://github.com/twostraws/Unwrap/issues/222) so that user will not able to rearrange the tableview rows after submitting the answer. As in coordinator we are sending computed property so if user rearrange the rows after submitting the question but before redirecting to next question then computed property will again compute the answer and provide points if user has rearranged the rows correctly.