### PR TITLE
Fix Minor SwiftLint Warning For Where Violation:

### DIFF
--- a/Unwrap/Activities/Practice/PredictTheOutput/PredictTheOutputPractice.swift
+++ b/Unwrap/Activities/Practice/PredictTheOutput/PredictTheOutputPractice.swift
@@ -65,11 +65,9 @@ struct PredictTheOutputPractice: PracticeActivity {
             guard let conditions = answer.conditions else { return answer }
 
             // Still here? Go through all conditions and check they are true for our values.
-            for condition in conditions {
-                if condition.evaluatesTrue(values: values, operators: operators) {
+            for condition in conditions where condition.evaluatesTrue(values: values, operators: operators) {
                     // All conditions are true, so use this answer.
                     return answer
-                }
             }
         }
 


### PR DESCRIPTION
This PR fixes a Minor SwiftLint Warning
For Where Violation: `where` clauses are preferred over a single `if` inside a `for`. (for_where)