### PR TITLE
Fixed Xcode 14 Warning for the Run script build phase

### DIFF
--- a/Unwrap.xcodeproj/project.pbxproj
+++ b/Unwrap.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2762,6 +2762,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		C90D15D421EA485C004116DB /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
This PR fixes the warning build: Run script build phase 'SwiftLint Run Script' will be run during every build because it does not specify any outputs.

![SCR-20220923-fbl](https://user-images.githubusercontent.com/4116539/191917283-32a902fe-0c88-4a2a-b25f-38aefce77662.png)

By unchecking "Based on dependency analysis" in the script phase thus configured to run in every build.